### PR TITLE
Add unbind tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,21 @@
 name: Drops Contract
 on: push
 jobs:
+    clang-formatting-check:
+        name: clang-format check
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                path:
+                    - 'src'
+                    - 'include/drops'
+        steps:
+            - uses: actions/checkout@v3
+            - name: Run clang-format style check
+              uses: jidicula/clang-format-action@v4.11.0
+              with:
+                  clang-format-version: '16'
+                  check-path: ${{ matrix.path }}
     test-node-js:
         runs-on: ubuntu-latest
         strategy:
@@ -23,12 +38,8 @@ jobs:
                   sudo apt install unzip
                   unzip cdt.zip
                   sudo apt install ./cdt_4.0.1-1_amd64.deb
-            - name: Install clang-format@16
-              run: sudo apt install clang-format-16.0
-            - name: Check clang-format
-              run: clang-format --version
             - name: Run checks
-              run: make check
+              run: make jscheck
             - name: Run build
               run: make build
             - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,10 @@ jobs:
                   sudo apt install unzip
                   unzip cdt.zip
                   sudo apt install ./cdt_4.0.1-1_amd64.deb
+            - name: Install clang-format@16
+              run: sudo apt install clang-format-16.0
+            - name: Check clang-format
+              run: clang-format --version
             - name: Run checks
               run: make check
             - name: Run build

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test: node_modules build
 check: cppcheck jscheck
 
 .PHONY: cppcheck
-cppcheck: 
+cppcheck:
 	clang-format --dry-run --Werror src/*.cpp include/drops/*.hpp
 
 .PHONY: jscheck

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,12 @@ test: node_modules build
 
 .PHONY: check
 check: node_modules
+	clang-format --dry-run --Werror src/*.cpp include/drops/*.hpp
 	@${BIN}/eslint src --ext .ts --max-warnings 0 --format unix && echo "Ok"
 
 .PHONY: format
 format: node_modules
+	clang-format -i src/*.cpp include/drops/*.hpp
 	@${BIN}/eslint src --ext .ts --fix
 
 .PHONY: distclean

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,25 @@ test: node_modules build
 	bun test
 
 .PHONY: check
-check: node_modules
+check: cppcheck jscheck
+
+.PHONY: cppcheck
+cppcheck: 
 	clang-format --dry-run --Werror src/*.cpp include/drops/*.hpp
+
+.PHONY: jscheck
+jscheck: node_modules
 	@${BIN}/eslint src --ext .ts --max-warnings 0 --format unix && echo "Ok"
 
 .PHONY: format
-format: node_modules
+format: cppformat jsformat
+
+.PHONY: cppformat
+cppformat:
 	clang-format -i src/*.cpp include/drops/*.hpp
+
+.PHONY: jsformat
+jsformat: node_modules
 	@${BIN}/eslint src --ext .ts --fix
 
 .PHONY: distclean

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <eosio/singleton.hpp>
 #include <eosio.system/eosio.system.hpp>
 #include <eosio.token/eosio.token.hpp>
+#include <eosio/singleton.hpp>
 
 #include <drops/drops.hpp>
 #include <drops/ram.hpp>
@@ -14,8 +14,8 @@ namespace dropssystem {
 
 static constexpr symbol EOS = symbol{"EOS", 4};
 
-static const string ERROR_INVALID_MEMO = "Invalid transfer memo. (ex: \"<amount>,<data>\")";
-static const string ERROR_DROP_NOT_FOUND = "Drop not found.";
+static const string ERROR_INVALID_MEMO    = "Invalid transfer memo. (ex: \"<amount>,<data>\")";
+static const string ERROR_DROP_NOT_FOUND  = "Drop not found.";
 static const string ERROR_SYSTEM_DISABLED = "Drops system is disabled.";
 
 uint128_t combine_ids(const uint64_t& v1, const uint64_t& v2) { return (uint128_t{v1} << 64) | v2; }
@@ -48,12 +48,12 @@ public:
     */
    struct [[eosio::table("drop")]] drop_row
    {
-      uint64_t          seed;
-      name              owner;
-      block_timestamp   created;
-      bool              bound;
-      uint64_t          primary_key() const { return seed; }
-      uint128_t         by_owner() const { return ((uint128_t)owner.value << 64) | seed; }
+      uint64_t        seed;
+      name            owner;
+      block_timestamp created;
+      bool            bound;
+      uint64_t        primary_key() const { return seed; }
+      uint128_t       by_owner() const { return ((uint128_t)owner.value << 64) | seed; }
    };
 
    /**
@@ -77,16 +77,16 @@ public:
     */
    struct [[eosio::table("state")]] state_row
    {
-      block_timestamp   genesis = current_block_time();
-      int64_t           bytes_per_drop = 512; // 144 bytes primary row + 368 bytes secondary row
-      bool              enabled = true;
+      block_timestamp genesis        = current_block_time();
+      int64_t         bytes_per_drop = 512; // 144 bytes primary row + 368 bytes secondary row
+      bool            enabled        = true;
    };
 
    struct [[eosio::table("unbind")]] unbind_row
    {
-      name                 owner;
-      vector<uint64_t>     drops_ids;
-      uint64_t             primary_key() const { return owner.value; }
+      name             owner;
+      vector<uint64_t> drops_ids;
+      uint64_t         primary_key() const { return owner.value; }
    };
 
    typedef eosio::multi_index<
@@ -94,7 +94,7 @@ public:
       drop_row,
       eosio::indexed_by<"owner"_n, eosio::const_mem_fun<drop_row, uint128_t, &drop_row::by_owner>>>
                                                       drop_table;
-   typedef eosio::singleton<"state"_n, state_row>   state_table;
+   typedef eosio::singleton<"state"_n, state_row>     state_table;
    typedef eosio::multi_index<"unbind"_n, unbind_row> unbind_table;
 
    /*
@@ -125,36 +125,30 @@ public:
    };
 
    // @user
-   [[eosio::on_notify("*::transfer")]]
-   generate_return_value on_transfer(const name from, const name to, const asset quantity, const string memo);
+   [[eosio::on_notify("*::transfer")]] generate_return_value
+   on_transfer(const name from, const name to, const asset quantity, const string memo);
 
    // @user
-   [[eosio::action]]
-   generate_return_value mint(const name owner, const uint32_t amount, const string data);
+   [[eosio::action]] generate_return_value mint(const name owner, const uint32_t amount, const string data);
 
    // @user
-   [[eosio::action]]
-   void transfer(const name from, const name to, const vector<uint64_t> drops_ids, const string memo);
+   [[eosio::action]] void transfer(const name from, const name to, const vector<uint64_t> drops_ids, const string memo);
 
    // @user
-   [[eosio::action]]
-   destroy_return_value destroy(const name owner, const vector<uint64_t> drops_ids, const string memo);
+   [[eosio::action]] destroy_return_value
+   destroy(const name owner, const vector<uint64_t> drops_ids, const string memo);
 
    // @user
-   [[eosio::action]]
-   bind_return_value bind(const name owner, const vector<uint64_t> drops_ids);
+   [[eosio::action]] bind_return_value bind(const name owner, const vector<uint64_t> drops_ids);
 
    // @user
-   [[eosio::action]]
-   void unbind(const name owner, const vector<uint64_t> drops_ids);
+   [[eosio::action]] void unbind(const name owner, const vector<uint64_t> drops_ids);
 
    // @user
-   [[eosio::action]]
-   void cancelunbind(const name owner);
+   [[eosio::action]] void cancelunbind(const name owner);
 
    // @admin
-   [[eosio::action]]
-   void enable(bool enabled);
+   [[eosio::action]] void enable(bool enabled);
 
    // action wrappers
    using mint_action         = eosio::action_wrapper<"mint"_n, &drops::mint>;
@@ -163,25 +157,24 @@ public:
    using bind_action         = eosio::action_wrapper<"bind"_n, &drops::bind>;
    using unbind_action       = eosio::action_wrapper<"unbind"_n, &drops::unbind>;
    using cancelunbind_action = eosio::action_wrapper<"cancelunbind"_n, &drops::cancelunbind>;
-   using enable_action = eosio::action_wrapper<"enable"_n, &drops::enable>;
+   using enable_action       = eosio::action_wrapper<"enable"_n, &drops::enable>;
 
-   // DEBUG (used to help testing)
-   #ifdef DEBUG
-   [[eosio::action]]
-   void test( const string data );
+// DEBUG (used to help testing)
+#ifdef DEBUG
+   [[eosio::action]] void test(const string data);
 
    // @debug
-   [[eosio::action]]
-   void cleartable( const name table_name, const optional<name> scope, const optional<uint64_t> max_rows );
-   #endif
+   [[eosio::action]] void
+   cleartable(const name table_name, const optional<name> scope, const optional<uint64_t> max_rows);
+#endif
 
 private:
-   generate_return_value do_generate(const name from, const asset quantity, const uint64_t amount, const string data );
+   generate_return_value do_generate(const name from, const asset quantity, const uint64_t amount, const string data);
    generate_return_value do_unbind(const name from, const asset quantity);
-   void check_is_enabled();
-   int64_t get_bytes_per_drop();
-   uint64_t hash_data( const string data );
-   void emplace_drops( const name ram_payer, const name owner, const string data, const uint64_t amount );
+   void                  check_is_enabled();
+   int64_t               get_bytes_per_drop();
+   uint64_t              hash_data(const string data);
+   void emplace_drops(const name ram_payer, const name owner, const string data, const uint64_t amount);
 
    void transfer_tokens(const name to, const asset quantity, const string memo);
    void transfer_ram(const name to, const int64_t bytes, const string memo);
@@ -189,21 +182,21 @@ private:
    void buy_ram_bytes(int64_t bytes);
    void sell_ram_bytes(int64_t bytes);
 
-   void modify_ram_payer( const uint64_t drop_id, const name ram_payer );
-   void check_drop_owner( const uint64_t drop_id, const name owner );
-   void check_drop_bound( const uint64_t drop_id, const bool bound );
-   drop_row get_drop(const uint64_t drop_id );
-   void modify_owner( const uint64_t drop_id, const name current_owner, const name new_owner );
+   void     modify_ram_payer(const uint64_t drop_id, const name ram_payer);
+   void     check_drop_owner(const uint64_t drop_id, const name owner);
+   void     check_drop_bound(const uint64_t drop_id, const bool bound);
+   drop_row get_drop(const uint64_t drop_id);
+   void     modify_owner(const uint64_t drop_id, const name current_owner, const name new_owner);
 
    // utils
    vector<string> split(const string& str, const char delim);
-   int64_t to_number(const string& str);
+   int64_t        to_number(const string& str);
 
-   // DEBUG (used to help testing)
-   #ifdef DEBUG
+// DEBUG (used to help testing)
+#ifdef DEBUG
    template <typename T>
-   void clear_table( T& table, uint64_t rows_to_clear );
-   #endif
+   void clear_table(T& table, uint64_t rows_to_clear);
+#endif
 };
 
 } // namespace dropssystem

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -195,9 +195,9 @@ private:
    void buy_ram_bytes(int64_t bytes);
    void sell_ram_bytes(int64_t bytes);
 
-   void modify_drop_binding( const name ram_payer, const name owner, const uint64_t drop_id );
-   void check_drop_ownership( const name owner, const uint64_t drop_id );
-   void check_drop_bound( const name owner, const uint64_t drop_id, const bool bound );
+   void modify_ram_payer( const uint64_t drop_id, const name ram_payer );
+   void check_drop_ownership( const uint64_t drop_id, const name owner );
+   void check_drop_bound( const uint64_t drop_id, const bool bound );
 
    // utils
    vector<string> split(const string& str, const char delim);

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -124,32 +124,37 @@ public:
       asset    redeemed;
    };
 
-   /*
-
-    User actions
-
-    */
-
+   // @user
    [[eosio::on_notify("*::transfer")]]
    generate_return_value on_transfer(const name from, const name to, const asset quantity, const string memo);
 
+   // @user
    [[eosio::action]]
    generate_return_value mint(const name owner, const uint32_t amount, const string data);
 
+   // @user
    [[eosio::action]]
    void transfer(const name from, const name to, const vector<uint64_t> drops_ids, const string memo);
 
+   // @user
    [[eosio::action]]
    destroy_return_value destroy(const name owner, const vector<uint64_t> drops_ids, const string memo);
 
+   // @user
    [[eosio::action]]
    bind_return_value bind(const name owner, const vector<uint64_t> drops_ids);
 
+   // @user
    [[eosio::action]]
    void unbind(const name owner, const vector<uint64_t> drops_ids);
 
+   // @user
    [[eosio::action]]
    void cancelunbind(const name owner);
+
+   // @admin
+   [[eosio::action]]
+   void enable(bool enabled);
 
    // action wrappers
    using mint_action         = eosio::action_wrapper<"mint"_n, &drops::mint>;
@@ -158,22 +163,7 @@ public:
    using bind_action         = eosio::action_wrapper<"bind"_n, &drops::bind>;
    using unbind_action       = eosio::action_wrapper<"unbind"_n, &drops::unbind>;
    using cancelunbind_action = eosio::action_wrapper<"cancelunbind"_n, &drops::cancelunbind>;
-
-   /*
-
-    Admin actions
-
-    */
-
-   [[eosio::action]]
-   void enable(bool enabled);
    using enable_action = eosio::action_wrapper<"enable"_n, &drops::enable>;
-
-   /*
-
-    Testnet actions
-
-    */
 
    // DEBUG (used to help testing)
    #ifdef DEBUG

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -173,7 +173,7 @@ public:
 
 private:
    generate_return_value do_generate(const name from, const asset quantity, const uint64_t amount, const string data );
-   generate_return_value do_unbind(name from, name to, asset quantity, std::vector<std::string> parsed);
+   generate_return_value do_unbind(const name from, const asset quantity);
    void check_is_enabled();
    int64_t get_bytes_per_drop();
    uint64_t hash_data( const string data );
@@ -185,7 +185,9 @@ private:
    void buy_ram_bytes(int64_t bytes);
    void sell_ram_bytes(int64_t bytes);
 
-   drop_row modify_drop_binding(name owner, uint64_t drop_id, bool bound);
+   void modify_drop_binding( const name ram_payer, const name owner, const uint64_t drop_id );
+   void check_drop_ownership( const name owner, const uint64_t drop_id );
+   void check_drop_bound( const name owner, const uint64_t drop_id, const bool bound );
 
    std::vector<std::string> split(const std::string& str, char delim);
 

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -126,19 +126,28 @@ public:
 
     */
 
-   [[eosio::on_notify("*::transfer")]] generate_return_value
-   on_transfer(const name from, const name to, const asset quantity, const string memo);
+   [[eosio::on_notify("*::transfer")]]
+   generate_return_value on_transfer(const name from, const name to, const asset quantity, const string memo);
 
-   [[eosio::action]] generate_return_value mint(const name owner, const uint32_t amount, const string data);
+   [[eosio::action]]
+   generate_return_value mint(const name owner, const uint32_t amount, const string data);
 
-   [[eosio::action]] void transfer(const name from, const name to, const vector<uint64_t> drops_ids, const string memo);
+   [[eosio::action]]
+   void transfer(const name from, const name to, const vector<uint64_t> drops_ids, const string memo);
 
-   [[eosio::action]] destroy_return_value destroy(const name owner, const vector<uint64_t> drops_ids, const string memo);
+   [[eosio::action]]
+   destroy_return_value destroy(const name owner, const vector<uint64_t> drops_ids, const string memo);
 
-   [[eosio::action]] bind_return_value bind(const name owner, const vector<uint64_t> drops_ids);
-   [[eosio::action]] void              unbind(const name owner, const vector<uint64_t> drops_ids);
-   [[eosio::action]] void              cancelunbind(const name owner);
+   [[eosio::action]]
+   bind_return_value bind(const name owner, const vector<uint64_t> drops_ids);
 
+   [[eosio::action]]
+   void unbind(const name owner, const vector<uint64_t> drops_ids);
+
+   [[eosio::action]]
+   void cancelunbind(const name owner);
+
+   // action wrappers
    using mint_action         = eosio::action_wrapper<"mint"_n, &drops::mint>;
    using transfer_action     = eosio::action_wrapper<"transfer"_n, &drops::transfer>;
    using destroy_action      = eosio::action_wrapper<"destroy"_n, &drops::destroy>;
@@ -152,7 +161,8 @@ public:
 
     */
 
-   [[eosio::action]] void enable(bool enabled);
+   [[eosio::action]]
+   void enable(bool enabled);
    using enable_action = eosio::action_wrapper<"enable"_n, &drops::enable>;
 
    /*

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -14,6 +14,10 @@ namespace dropssystem {
 
 static constexpr symbol EOS = symbol{"EOS", 4};
 
+static const string ERROR_INVALID_MEMO = "Invalid transfer memo. (ex: \"<amount>,<data>\")";
+static const string ERROR_DROP_NOT_FOUND = "Drop not found.";
+static const string ERROR_SYSTEM_DISABLED = "Drops system is disabled.";
+
 uint128_t combine_ids(const uint64_t& v1, const uint64_t& v2) { return (uint128_t{v1} << 64) | v2; }
 
 class [[eosio::contract("drops")]] drops : public contract

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -199,7 +199,9 @@ private:
    void check_drop_ownership( const name owner, const uint64_t drop_id );
    void check_drop_bound( const name owner, const uint64_t drop_id, const bool bound );
 
+   // utils
    vector<string> split(const string& str, const char delim);
+   int64_t to_number(const string& str);
 
    // DEBUG (used to help testing)
    #ifdef DEBUG

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -171,22 +171,21 @@ public:
 private:
    generate_return_value do_generate(const name from, const asset quantity, const uint64_t amount, const string data);
    generate_return_value do_unbind(const name from, const asset quantity);
-   void                  check_is_enabled();
-   int64_t               get_bytes_per_drop();
-   uint64_t              hash_data(const string data);
-   void emplace_drops(const name ram_payer, const name owner, const string data, const uint64_t amount);
+
+   int64_t  get_bytes_per_drop();
+   uint64_t hash_data(const string data);
 
    void transfer_tokens(const name to, const asset quantity, const string memo);
    void transfer_ram(const name to, const int64_t bytes, const string memo);
-
    void buy_ram_bytes(int64_t bytes);
    void sell_ram_bytes(int64_t bytes);
 
-   void     modify_ram_payer(const uint64_t drop_id, const name ram_payer);
-   void     check_drop_owner(const uint64_t drop_id, const name owner);
-   void     check_drop_bound(const uint64_t drop_id, const bool bound);
-   drop_row get_drop(const uint64_t drop_id);
-   void     modify_owner(const uint64_t drop_id, const name current_owner, const name new_owner);
+   void check_is_enabled();
+   void check_drop_owner(const drop_row drop, const name owner);
+   void check_drop_bound(const drop_row drop, const bool bound);
+   void modify_owner(const uint64_t drop_id, const name current_owner, const name new_owner);
+   void modify_ram_payer(const uint64_t drop_id, const name owner, const name ram_payer);
+   void emplace_drops(const name ram_payer, const name owner, const string data, const uint64_t amount);
 
    // utils
    vector<string> split(const string& str, const char delim);

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -80,9 +80,9 @@ public:
 
    struct [[eosio::table("unbind")]] unbind_row
    {
-      name                  owner;
-      std::vector<uint64_t> drops_ids;
-      uint64_t              primary_key() const { return owner.value; }
+      name                 owner;
+      vector<uint64_t>     drops_ids;
+      uint64_t             primary_key() const { return owner.value; }
    };
 
    typedef eosio::multi_index<
@@ -127,17 +127,17 @@ public:
     */
 
    [[eosio::on_notify("*::transfer")]] generate_return_value
-   on_transfer(name from, name to, asset quantity, std::string memo);
+   on_transfer(const name from, const name to, const asset quantity, const string memo);
 
-   [[eosio::action]] generate_return_value mint(name owner, uint32_t amount, std::string data);
+   [[eosio::action]] generate_return_value mint(const name owner, const uint32_t amount, const string data);
 
-   [[eosio::action]] void transfer(name from, name to, std::vector<uint64_t> drops_ids, string memo);
+   [[eosio::action]] void transfer(const name from, const name to, const vector<uint64_t> drops_ids, const string memo);
 
-   [[eosio::action]] destroy_return_value destroy(name owner, std::vector<uint64_t> drops_ids, string memo);
+   [[eosio::action]] destroy_return_value destroy(const name owner, const vector<uint64_t> drops_ids, const string memo);
 
    [[eosio::action]] bind_return_value bind(const name owner, const vector<uint64_t> drops_ids);
    [[eosio::action]] void              unbind(const name owner, const vector<uint64_t> drops_ids);
-   [[eosio::action]] void              cancelunbind(name owner);
+   [[eosio::action]] void              cancelunbind(const name owner);
 
    using mint_action         = eosio::action_wrapper<"mint"_n, &drops::mint>;
    using transfer_action     = eosio::action_wrapper<"transfer"_n, &drops::transfer>;
@@ -179,8 +179,8 @@ private:
    uint64_t hash_data( const string data );
    void emplace_drops( const name ram_payer, const name owner, const string data, const uint64_t amount );
 
-   void transfer_tokens(name to, asset amount, string memo);
-   void transfer_ram(name to, asset amount, string memo);
+   void transfer_tokens(const name to, const asset quantity, const string memo);
+   void transfer_ram(const name to, const int64_t bytes, const string memo);
 
    void buy_ram_bytes(int64_t bytes);
    void sell_ram_bytes(int64_t bytes);
@@ -189,7 +189,7 @@ private:
    void check_drop_ownership( const name owner, const uint64_t drop_id );
    void check_drop_bound( const name owner, const uint64_t drop_id, const bool bound );
 
-   std::vector<std::string> split(const std::string& str, char delim);
+   vector<string> split(const string& str, const char delim);
 
    // DEBUG (used to help testing)
    #ifdef DEBUG

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -135,8 +135,8 @@ public:
 
    [[eosio::action]] destroy_return_value destroy(name owner, std::vector<uint64_t> drops_ids, string memo);
 
-   [[eosio::action]] bind_return_value bind(name owner, std::vector<uint64_t> drops_ids);
-   [[eosio::action]] void              unbind(name owner, std::vector<uint64_t> drops_ids);
+   [[eosio::action]] bind_return_value bind(const name owner, const vector<uint64_t> drops_ids);
+   [[eosio::action]] void              unbind(const name owner, const vector<uint64_t> drops_ids);
    [[eosio::action]] void              cancelunbind(name owner);
 
    using mint_action         = eosio::action_wrapper<"mint"_n, &drops::mint>;

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -190,8 +190,10 @@ private:
    void sell_ram_bytes(int64_t bytes);
 
    void modify_ram_payer( const uint64_t drop_id, const name ram_payer );
-   void check_drop_ownership( const uint64_t drop_id, const name owner );
+   void check_drop_owner( const uint64_t drop_id, const name owner );
    void check_drop_bound( const uint64_t drop_id, const bool bound );
+   drop_row get_drop(const uint64_t drop_id );
+   void modify_owner( const uint64_t drop_id, const name new_owner );
 
    // utils
    vector<string> split(const string& str, const char delim);

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -193,7 +193,7 @@ private:
    void check_drop_owner( const uint64_t drop_id, const name owner );
    void check_drop_bound( const uint64_t drop_id, const bool bound );
    drop_row get_drop(const uint64_t drop_id );
-   void modify_owner( const uint64_t drop_id, const name new_owner );
+   void modify_owner( const uint64_t drop_id, const name current_owner, const name new_owner );
 
    // utils
    vector<string> split(const string& str, const char delim);

--- a/include/drops/ram.hpp
+++ b/include/drops/ram.hpp
@@ -2,10 +2,10 @@ namespace eosiosystem {
 
 int64_t get_bancor_input(int64_t out_reserve, int64_t inp_reserve, int64_t out);
 
-asset ramcost(uint32_t bytes, symbol core_symbol);
+asset ram_cost(uint32_t bytes, symbol core_symbol);
 
-asset ramcostwithfee(uint32_t bytes, symbol core_symbol);
+asset ram_cost_with_fee(uint32_t bytes, symbol core_symbol);
 
-asset ramproceedstminusfee(uint32_t bytes, symbol core_symbol);
+asset ram_proceeds_minus_fee(uint32_t bytes, symbol core_symbol);
 
 } // namespace eosiosystem

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1,37 +1,36 @@
 namespace dropssystem {
 
 // @debug
-[[eosio::action]]
-void drops::test( const string data )
-{
-    print(data);
-}
+[[eosio::action]] void drops::test(const string data) { print(data); }
 
 // @debug
 template <typename T>
-void drops::clear_table( T& table, uint64_t rows_to_clear )
+void drops::clear_table(T& table, uint64_t rows_to_clear)
 {
-    auto itr = table.begin();
-    while ( itr != table.end() && rows_to_clear-- ) {
-        itr = table.erase( itr );
-    }
+   auto itr = table.begin();
+   while (itr != table.end() && rows_to_clear--) {
+      itr = table.erase(itr);
+   }
 }
 
 // @debug
-[[eosio::action]]
-void drops::cleartable( const name table_name, const optional<name> scope, const optional<uint64_t> max_rows )
+[[eosio::action]] void
+drops::cleartable(const name table_name, const optional<name> scope, const optional<uint64_t> max_rows)
 {
-    require_auth( get_self() );
-    const uint64_t rows_to_clear = (!max_rows || *max_rows == 0) ? -1 : *max_rows;
-    const uint64_t value = scope ? scope->value : get_self().value;
+   require_auth(get_self());
+   const uint64_t rows_to_clear = (!max_rows || *max_rows == 0) ? -1 : *max_rows;
+   const uint64_t value         = scope ? scope->value : get_self().value;
 
-    // tables
-    drops::state_table _state( get_self(), value );
-    drops::drop_table _drop( get_self(), value );
+   // tables
+   drops::state_table _state(get_self(), value);
+   drops::drop_table  _drop(get_self(), value);
 
-    if (table_name == "drop"_n) clear_table( _drop, rows_to_clear );
-    else if (table_name == "state"_n) _state.remove();
-    else check(false, "cleartable: [table_name] unknown table to clear" );
+   if (table_name == "drop"_n)
+      clear_table(_drop, rows_to_clear);
+   else if (table_name == "state"_n)
+      _state.remove();
+   else
+      check(false, "cleartable: [table_name] unknown table to clear");
 }
 
 } // namespace dropssystem

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -79,7 +79,7 @@ drops::generate_return_value drops::do_unbind(const name from, const asset quant
    check_is_enabled();
 
    // Find the unbind request of the owner
-   unbind_table unbinds(_self, _self.value);
+   unbind_table unbinds(get_self(), get_self().value);
    auto         unbinds_itr = unbinds.find(from.value);
    check(unbinds_itr != unbinds.end(), "No unbind request found for account.");
 
@@ -186,7 +186,7 @@ uint64_t drops::hash_data( const string data )
    require_recipient(to);
 
    // Iterate over all drops selected to be transferred
-   drops::drop_table drops(_self, _self.value);
+   drops::drop_table drops(get_self(), get_self().value);
    for ( const uint64_t drop_id : drops_ids ) {
       auto drops_itr = drops.find(drop_id);
       check(drops_itr != drops.end(), "Drop " + to_string(drops_itr->seed) + " not found");
@@ -201,7 +201,7 @@ uint64_t drops::hash_data( const string data )
 void drops::buy_ram_bytes(const int64_t bytes)
 {
    eosiosystem::system_contract::buyrambytes_action buyrambytes{"eosio"_n, {_self, "active"_n}};
-   buyrambytes.send(_self, _self, bytes);
+   buyrambytes.send(get_self(), _self, bytes);
 }
 
 void drops::sell_ram_bytes(const int64_t bytes)
@@ -314,7 +314,7 @@ void drops::check_drop_ownership( const name owner, const uint64_t drop_id )
    check_is_enabled();
 
    // Remove the unbind request of the owner
-   unbind_table unbinds(_self, _self.value);
+   unbind_table unbinds(get_self(), get_self().value);
    auto         unbinds_itr = unbinds.find(owner.value);
    check(unbinds_itr != unbinds.end(), "No unbind request found for account.");
    unbinds.erase(unbinds_itr);
@@ -327,7 +327,7 @@ void drops::check_drop_ownership( const name owner, const uint64_t drop_id )
 
    check(drops_ids.size() > 0, "No drops were provided to destroy.");
 
-   drops::drop_table drops(_self, _self.value);
+   drops::drop_table drops(get_self(), get_self().value);
 
    // The number of bound drops that were destroyed
    int bound_destroyed = 0;

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -193,19 +193,18 @@ void drops::transfer(const name from, const name to, const vector<uint64_t> drop
    // Iterate over all drops selected to be transferred
    drops::drop_table drops(get_self(), get_self().value);
    for ( const uint64_t drop_id : drops_ids ) {
-      auto drops_itr = drops.find(drop_id);
-      check(drops_itr != drops.end(), "Drop " + to_string(drops_itr->seed) + " not found");
-      check(drops_itr->bound == false, "Drop " + to_string(drops_itr->seed) + " is bound and cannot be transferred");
-      check(drops_itr->owner == from, "Account does not own drop" + to_string(drops_itr->seed));
+      auto drop = drops.get(drop_id, ERROR_DROP_NOT_FOUND.c_str());
+      check(drop.bound == false, "Drop " + to_string(drop.seed) + " is bound and cannot be transferred");
+      check(drop.owner == from, "Account does not own drop" + to_string(drop.seed));
       // Perform the transfer
-      drops.modify(drops_itr, _self, [&](auto& row) { row.owner = to; });
+      drops.modify(drop, get_self(), [&](auto& row) { row.owner = to; });
    }
 }
 
 void drops::buy_ram_bytes(const int64_t bytes)
 {
-   eosiosystem::system_contract::buyrambytes_action buyrambytes{"eosio"_n, {_self, "active"_n}};
-   buyrambytes.send(get_self(), _self, bytes);
+   eosiosystem::system_contract::buyrambytes_action buyrambytes{"eosio"_n, {get_self(), "active"_n}};
+   buyrambytes.send(get_self(), get_self(), bytes);
 }
 
 void drops::sell_ram_bytes(const int64_t bytes)

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -192,16 +192,18 @@ void drops::transfer(const name from, const name to, const vector<uint64_t> drop
 
    // Iterate over all drops selected to be transferred
    for ( const uint64_t drop_id : drops_ids ) {
-      check_drop_owner(drop_id, from);
-      check_drop_bound(drop_id, false);
-      modify_owner(drop_id, to);
+      modify_owner(drop_id, from, to);
    }
 }
 
-void drops::modify_owner( const uint64_t drop_id, const name new_owner )
+void drops::modify_owner( const uint64_t drop_id, const name current_owner, const name new_owner )
 {
    drops::drop_table drops(get_self(), get_self().value);
-   auto & drop = drops.require_find(drop_id, ERROR_DROP_NOT_FOUND.c_str());
+   auto drop = drops.require_find(drop_id, ERROR_DROP_NOT_FOUND.c_str());
+
+   // additional checks
+   check_drop_owner(drop_id, current_owner);
+   check_drop_bound(drop_id, false);
 
    // Modify owner
    drops.modify(drop, same_payer, [&](auto& row) {
@@ -235,7 +237,7 @@ void drops::transfer_ram(const name to, const int64_t bytes, const string memo) 
 void drops::modify_ram_payer( const uint64_t drop_id, const name ram_payer )
 {
    drops::drop_table drops(get_self(), get_self().value);
-   auto & drop = drops.require_find(drop_id, ERROR_DROP_NOT_FOUND.c_str());
+   auto drop = drops.require_find(drop_id, ERROR_DROP_NOT_FOUND.c_str());
 
    // Modify RAM payer
    drops.modify(drop, ram_payer, [&](auto& row) {

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -235,16 +235,16 @@ void drops::modify_drop_binding(const name ram_payer, const name owner, const ui
    });
 }
 
-[[eosio::action]] drops::bind_return_value drops::bind(name owner, std::vector<uint64_t> drops_ids)
+[[eosio::action]] drops::bind_return_value drops::bind(const name owner, const vector<uint64_t> drops_ids)
 {
    require_auth(owner);
    check_is_enabled();
 
    check(drops_ids.size() > 0, "No drops were provided to transfer.");
 
-   drops::drop_table drops(_self, _self.value);
-
    for ( const uint64_t drop_id : drops_ids ) {
+      check_drop_ownership(owner, drop_id);
+      check_drop_bound(owner, drop_id, false);
       modify_drop_binding(owner, owner, drop_id);
    }
 

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -31,7 +31,8 @@ drops::generate_return_value drops::on_transfer(const name from, const name to, 
       check(parsed.size() == 2, "Memo data must contain 2 values, seperated by a "
                                 "comma using format: <drops_amount>,<drops_data>");
 
-      const uint64_t amount = stoi(parsed[0]);
+      const int64_t amount = to_number(parsed[0]);
+      check( amount > 0, "The amount of drops to generate must be a positive value.");
       const string data = parsed[1];
       return do_generate(from, quantity, amount, data);
    }
@@ -407,6 +408,21 @@ vector<string> drops::split(const string& str, const char delim)
       strings.push_back(str.substr(start, end - start));
    }
    return strings;
+}
+
+int64_t drops::to_number(const std::string& str) {
+    if (str.empty()) return 0;
+
+    char* end;
+    uint64_t num = std::strtoull(str.c_str(), &end, 10);
+
+    // Check if conversion was successful
+    check(*end == '\0', "invalid number format or overflow");
+
+    // Check for underflow
+    check(num <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max()), "number underflow");
+
+    return static_cast<int64_t>(num);
 }
 
 } // namespace dropssystem

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -313,7 +313,7 @@ void drops::check_drop_ownership( const name owner, const uint64_t drop_id )
 }
 
 [[eosio::action]]
-void drops::cancelunbind(name owner)
+void drops::cancelunbind(const name owner)
 {
    require_auth(owner);
    check_is_enabled();

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -9,6 +9,7 @@
 
 namespace dropssystem {
 
+// @user
 [[eosio::on_notify("*::transfer")]]
 drops::generate_return_value drops::on_transfer(const name from, const name to, const asset quantity, const string memo)
 {
@@ -122,6 +123,7 @@ drops::generate_return_value drops::do_unbind(const name from, const asset quant
    };
 }
 
+// @user
 [[eosio::action]]
 drops::generate_return_value drops::mint(const name owner, const uint32_t amount, const string data)
 {
@@ -175,6 +177,7 @@ uint64_t drops::hash_data( const string data )
    return seed;
 }
 
+// @user
 [[eosio::action]]
 void drops::transfer(const name from, const name to, const vector<uint64_t> drops_ids, const string memo)
 {
@@ -237,6 +240,7 @@ void drops::modify_ram_payer( const uint64_t drop_id, const name ram_payer )
    });
 }
 
+// @user
 [[eosio::action]]
 drops::bind_return_value drops::bind(const name owner, const vector<uint64_t> drops_ids)
 {
@@ -269,6 +273,7 @@ drops::bind_return_value drops::bind(const name owner, const vector<uint64_t> dr
    };
 }
 
+// @user
 [[eosio::action]]
 void drops::unbind(const name owner, const vector<uint64_t> drops_ids)
 {
@@ -308,6 +313,7 @@ void drops::check_drop_ownership( const uint64_t drop_id, const name owner )
    check(drop.owner == owner, "Drop " + to_string(drop_id) + " does not belong to account.");
 }
 
+// @user
 [[eosio::action]]
 void drops::cancelunbind(const name owner)
 {
@@ -321,6 +327,7 @@ void drops::cancelunbind(const name owner)
    unbinds.erase(unbind);
 }
 
+// @user
 [[eosio::action]]
 drops::destroy_return_value drops::destroy(const name owner, const vector<uint64_t> drops_ids, const string memo)
 {
@@ -367,6 +374,7 @@ drops::destroy_return_value drops::destroy(const name owner, const vector<uint64
    };
 }
 
+// @admin
 [[eosio::action]]
 void drops::enable(const bool enabled)
 {

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -55,7 +55,7 @@ drops::generate_return_value drops::do_generate(const name from, const asset qua
 
    // Calculate the purchase cost via bancor after the purchase to ensure the
    // incoming transfer can cover it
-   asset ram_purchase_cost = eosiosystem::ramcostwithfee(ram_purchase_amount, EOS);
+   asset ram_purchase_cost = eosiosystem::ram_cost_with_fee(ram_purchase_amount, EOS);
    check(quantity.amount >= ram_purchase_cost.amount,
          "The amount sent does not cover the RAM purchase cost (requires " + ram_purchase_cost.to_string() + ")");
 
@@ -100,7 +100,7 @@ drops::generate_return_value drops::do_unbind(const name from, const asset quant
 
    // Calculate the purchase cost via bancor after the purchase to ensure the
    // incoming transfer can cover it
-   asset ram_purchase_cost = eosiosystem::ramcostwithfee(ram_purchase_amount, EOS);
+   asset ram_purchase_cost = eosiosystem::ram_cost_with_fee(ram_purchase_amount, EOS);
    check(quantity.amount >= ram_purchase_cost.amount,
          "The amount sent does not cover the RAM purchase cost (requires " + ram_purchase_cost.to_string() + ")");
 
@@ -256,7 +256,7 @@ drops::bind_return_value drops::bind(const name owner, const vector<uint64_t> dr
 
    // Calculate RAM sell amount and reclaim value
    uint64_t ram_sell_amount   = drops_ids.size() * get_bytes_per_drop();
-   asset    ram_sell_proceeds = eosiosystem::ramproceedstminusfee(ram_sell_amount, EOS);
+   asset    ram_sell_proceeds = eosiosystem::ram_proceeds_minus_fee(ram_sell_amount, EOS);
 
    if (ram_sell_amount > 0) {
       // Sell the excess RAM no longer used by the contract
@@ -356,7 +356,7 @@ drops::destroy_return_value drops::destroy(const name owner, const vector<uint64
    // Calculate RAM sell amount and proceeds
    const int64_t record_size = get_bytes_per_drop();
    uint64_t ram_sell_amount   = (drops_ids.size() - bound_destroyed) * record_size;
-   asset    ram_sell_proceeds = eosiosystem::ramproceedstminusfee(ram_sell_amount, EOS);
+   asset    ram_sell_proceeds = eosiosystem::ram_proceeds_minus_fee(ram_sell_amount, EOS);
    if (ram_sell_amount > 0) {
       sell_ram_bytes(ram_sell_amount);
       transfer_tokens(owner, ram_sell_proceeds,

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -9,8 +9,8 @@
 
 namespace dropssystem {
 
-[[eosio::on_notify("*::transfer")]] drops::generate_return_value
-drops::on_transfer(const name from, const name to, const asset quantity, const string memo)
+[[eosio::on_notify("*::transfer")]]
+drops::generate_return_value drops::on_transfer(const name from, const name to, const asset quantity, const string memo)
 {
    if (from == "eosio.ram"_n ) return {}; // ignore RAM sales
    if (to != get_self()) return {}; // ignore transfers not sent to this contract
@@ -122,7 +122,8 @@ drops::generate_return_value drops::do_unbind(const name from, const asset quant
    };
 }
 
-[[eosio::action]] drops::generate_return_value drops::mint(const name owner, const uint32_t amount, const string data)
+[[eosio::action]]
+drops::generate_return_value drops::mint(const name owner, const uint32_t amount, const string data)
 {
    require_auth(owner);
    check_is_enabled();
@@ -174,7 +175,8 @@ uint64_t drops::hash_data( const string data )
    return seed;
 }
 
-[[eosio::action]] void drops::transfer(const name from, const name to, const vector<uint64_t> drops_ids, const string memo)
+[[eosio::action]]
+void drops::transfer(const name from, const name to, const vector<uint64_t> drops_ids, const string memo)
 {
    require_auth(from);
    check_is_enabled();
@@ -237,7 +239,8 @@ void drops::modify_drop_binding(const name ram_payer, const name owner, const ui
    });
 }
 
-[[eosio::action]] drops::bind_return_value drops::bind(const name owner, const vector<uint64_t> drops_ids)
+[[eosio::action]]
+drops::bind_return_value drops::bind(const name owner, const vector<uint64_t> drops_ids)
 {
    require_auth(owner);
    check_is_enabled();
@@ -269,7 +272,8 @@ void drops::modify_drop_binding(const name ram_payer, const name owner, const ui
    };
 }
 
-[[eosio::action]] void drops::unbind(const name owner, const vector<uint64_t> drops_ids)
+[[eosio::action]]
+void drops::unbind(const name owner, const vector<uint64_t> drops_ids)
 {
    require_auth(owner);
    check_is_enabled();
@@ -308,7 +312,8 @@ void drops::check_drop_ownership( const name owner, const uint64_t drop_id )
    check(drops_itr->owner == owner, "Drop " + to_string(drop_id) + " does not belong to account.");
 }
 
-[[eosio::action]] void drops::cancelunbind(name owner)
+[[eosio::action]]
+void drops::cancelunbind(name owner)
 {
    require_auth(owner);
    check_is_enabled();
@@ -320,7 +325,8 @@ void drops::check_drop_ownership( const name owner, const uint64_t drop_id )
    unbinds.erase(unbinds_itr);
 }
 
-[[eosio::action]] drops::destroy_return_value drops::destroy(const name owner, const vector<uint64_t> drops_ids, const string memo)
+[[eosio::action]]
+drops::destroy_return_value drops::destroy(const name owner, const vector<uint64_t> drops_ids, const string memo)
 {
    require_auth(owner);
    check_is_enabled();
@@ -366,7 +372,8 @@ void drops::check_drop_ownership( const name owner, const uint64_t drop_id )
    };
 }
 
-[[eosio::action]] void drops::enable(const bool enabled)
+[[eosio::action]]
+void drops::enable(const bool enabled)
 {
    require_auth(get_self());
 

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -227,7 +227,7 @@ void drops::transfer_ram(const name to, const int64_t bytes, const string memo) 
 void drops::modify_ram_payer( const uint64_t drop_id, const name ram_payer )
 {
    drops::drop_table drops(get_self(), get_self().value);
-   auto & drop = drops.get(drop_id, ERROR_DROP_NOT_FOUND);
+   auto & drop = drops.get(drop_id, ERROR_DROP_NOT_FOUND.c_str());
 
    // Modify RAM payer
    drops.modify(drop, ram_payer, [&](auto& row) {
@@ -301,7 +301,7 @@ void drops::check_drop_bound( const uint64_t drop_id, const bool bound )
 {
    drop_table drops(get_self(), get_self().value);
 
-   auto drop = drops.get(drop_id, ERROR_DROP_NOT_FOUND);
+   auto drop = drops.get(drop_id, ERROR_DROP_NOT_FOUND.c_str());
    check(drop.bound == bound, "Drop " + to_string(drop_id) + " is not " + (bound ? "bound" : "unbound") );
 }
 
@@ -309,7 +309,7 @@ void drops::check_drop_ownership( const uint64_t drop_id, const name owner )
 {
    drop_table drops(get_self(), get_self().value);
 
-   auto drop = drops.get(drop_id, ERROR_DROP_NOT_FOUND);
+   auto drop = drops.get(drop_id, ERROR_DROP_NOT_FOUND.c_str());
    check(drop.owner == owner, "Drop " + to_string(drop_id) + " does not belong to account.");
 }
 
@@ -343,15 +343,16 @@ drops::destroy_return_value drops::destroy(const name owner, const vector<uint64
 
    // Loop to destroy specified drops
    for ( const uint64_t drop_id : drops_ids ) {
-      auto & drop = drops.get(drop_id, ERROR_DROP_NOT_FOUND);
+      auto & drop = drops.get(drop_id, ERROR_DROP_NOT_FOUND.c_str());
       check_drop_ownership(drop_id, owner);
-      // Destroy the drops
-      drops.erase(drop);
       // Count the number of bound drops destroyed
       // This will be subtracted from the amount paid out
       if (drop.bound) {
          bound_destroyed++;
       }
+
+      // Destroy the drops
+      drops.erase(drop);
    }
 
    // Calculate RAM sell amount and proceeds

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -204,16 +204,19 @@ describe(core_contract, () => {
 
     test('unbind::error - not found', async () => {
         const action = contracts.core.actions.unbind([bob, ['123']]).send(bob)
-        await expectToThrow(action, 'eosio_assert_message: Drop 123 not found.');
+        await expectToThrow(action, 'eosio_assert_message: Drop 123 not found.')
     })
 
     test('unbind::error - does not belong to account', async () => {
         const action = contracts.core.actions.unbind([alice, ['10272988527514872302']]).send(alice)
-        await expectToThrow(action, 'eosio_assert_message: Drop 10272988527514872302 does not belong to account.');
+        await expectToThrow(
+            action,
+            'eosio_assert_message: Drop 10272988527514872302 does not belong to account.'
+        )
     })
 
     test('unbind::error - is not unbound', async () => {
         const action = contracts.core.actions.unbind([bob, ['10272988527514872302']]).send(bob)
-        await expectToThrow(action, 'eosio_assert_message: Drop 10272988527514872302 is not bound');
+        await expectToThrow(action, 'eosio_assert_message: Drop 10272988527514872302 is not bound')
     })
 })

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -250,7 +250,7 @@ describe(core_contract, () => {
 
     test('unbind::error - not found', async () => {
         const action = contracts.core.actions.unbind([bob, ['123']]).send(bob)
-        await expectToThrow(action, 'eosio_assert_message: Drop 123 not found.')
+        await expectToThrow(action, 'eosio_assert: Drop not found.')
     })
 
     test('unbind::error - does not belong to account', async () => {
@@ -281,7 +281,7 @@ describe(core_contract, () => {
 
     test('bind::error - not found', async () => {
         const action = contracts.core.actions.bind([bob, ['123']]).send(bob)
-        await expectToThrow(action, 'eosio_assert_message: Drop 123 not found.')
+        await expectToThrow(action, 'eosio_assert: Drop not found.')
     })
 
     test('bind::error - does not belong to account', async () => {

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -227,7 +227,7 @@ describe(core_contract, () => {
         )
     })
 
-    test('unbind::error - is not unbound', async () => {
+    test('unbind::error - is not bound', async () => {
         const action = contracts.core.actions.unbind([bob, ['10272988527514872302']]).send(bob)
         await expectToThrow(action, 'eosio_assert_message: Drop 10272988527514872302 is not bound')
     })
@@ -258,7 +258,7 @@ describe(core_contract, () => {
         )
     })
 
-    test('bind::error - is not bound', async () => {
+    test('bind::error - is not unbound', async () => {
         const action = contracts.core.actions.bind([bob, ['10272988527514872302']]).send(bob)
         await expectToThrow(
             action,
@@ -274,7 +274,7 @@ describe(core_contract, () => {
         expect(getUnbind(bob).length).toBe(0)
     })
 
-    test('cancelunbind::error - is not bound', async () => {
+    test('cancelunbind::error - No unbind request', async () => {
         const action = contracts.core.actions.cancelunbind([bob]).send(bob)
         await expectToThrow(action, 'eosio_assert: No unbind request found for account.')
     })

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -122,6 +122,40 @@ describe(core_contract, () => {
         })
     })
 
+    test('on_transfer::error - empty memo', async () => {
+        const action = contracts.token.actions
+            .transfer([alice, core_contract, '10.0000 EOS', ''])
+            .send(alice)
+        await expectToThrow(
+            action,
+            'eosio_assert: A memo is required to send tokens to this contract'
+        )
+    })
+
+    test('on_transfer::error - invalid number', async () => {
+        const action = contracts.token.actions
+            .transfer([alice, core_contract, '10.0000 EOS', 'foo,bar'])
+            .send(alice)
+        await expectToThrow(action, 'eosio_assert: invalid number format or overflow')
+    })
+
+    test('on_transfer::error - number underflow', async () => {
+        const action = contracts.token.actions
+            .transfer([alice, core_contract, '10.0000 EOS', '-1,bar'])
+            .send(alice)
+        await expectToThrow(action, 'eosio_assert: number underflow')
+    })
+
+    test('on_transfer::error - at least 32 characters', async () => {
+        const action = contracts.token.actions
+            .transfer([alice, core_contract, '10.0000 EOS', '1,foobar'])
+            .send(alice)
+        await expectToThrow(
+            action,
+            'eosio_assert: Drop data must be at least 32 characters in length.'
+        )
+    })
+
     test('mint', async () => {
         await contracts.core.actions.mint([bob, 1, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb']).send(bob)
 

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -76,6 +76,8 @@ function getUnbind(owner?: string) {
     return rows.filter((row) => row.owner === owner)
 }
 
+const ERROR_INVALID_MEMO = `eosio_assert_message: Invalid transfer memo. (ex: "<amount>,<data>")`
+
 describe(core_contract, () => {
     test('eosio::init', async () => {
         await contracts.system.actions.init([]).send()
@@ -126,10 +128,7 @@ describe(core_contract, () => {
         const action = contracts.token.actions
             .transfer([alice, core_contract, '10.0000 EOS', ''])
             .send(alice)
-        await expectToThrow(
-            action,
-            'eosio_assert: A memo is required to send tokens to this contract'
-        )
+        await expectToThrow(action, ERROR_INVALID_MEMO)
     })
 
     test('on_transfer::error - invalid number', async () => {
@@ -212,7 +211,7 @@ describe(core_contract, () => {
 
     test('destroy::error - not found', async () => {
         const action = contracts.core.actions.destroy([alice, ['123'], 'memo']).send(alice)
-        await expectToThrow(action, 'eosio_assert_message: Drop 123 not found')
+        await expectToThrow(action, 'eosio_assert: Drop not found.')
     })
 
     test('destroy::error - must belong to owner', async () => {

--- a/src/ram.cpp
+++ b/src/ram.cpp
@@ -41,7 +41,7 @@ double round_to(double value, double precision = 1.0, bool up = false)
    }
 }
 
-asset ramcost(uint32_t bytes, symbol core_symbol)
+asset ram_cost(uint32_t bytes, symbol core_symbol)
 {
    name          system_account = "eosio"_n;
    rammarket     _rammarket(system_account, system_account.value);
@@ -52,15 +52,15 @@ asset ramcost(uint32_t bytes, symbol core_symbol)
    return asset{cost, core_symbol};
 }
 
-asset ramcostwithfee(uint32_t bytes, symbol core_symbol)
+asset ram_cost_with_fee(uint32_t bytes, symbol core_symbol)
 {
-   const asset   cost          = ramcost(bytes, core_symbol);
+   const asset   cost          = ram_cost(bytes, core_symbol);
    const int64_t cost_plus_fee = cost.amount / double(0.995);
    return asset{cost_plus_fee, core_symbol};
 }
 
 // asset direct_convert(const asset& from, const symbol& to)
-asset ramproceedstminusfee(uint32_t bytes, symbol core_symbol)
+asset ram_proceeds_minus_fee(uint32_t bytes, symbol core_symbol)
 {
    asset from = asset{bytes, system_contract::ram_symbol};
 


### PR DESCRIPTION
## What's changed
- [x] added `int64_t to_number(str)` method to parse number from memo
- [x] added `const` to methods
- [x] renamed `_self` to `get_self()` (ref: [eosio.system](https://github.com/eosnetworkfoundation/eos-system-contracts/blob/c6113dbec2282825ce8d1fb6396fe82500af9019/contracts/eosio.system/src/eosio.system.cpp#L491))
- [x] ~move `[eosio::action]` on top of method (ref: [eosio.system](https://github.com/eosnetworkfoundation/eos-system-contracts/blob/c6113dbec2282825ce8d1fb6396fe82500af9019/contracts/eosio.system/include/eosio.system/eosio.system.hpp#L1120-L1121]))~

```c++
[[eosio::action]]
void drops::enable(const bool enabled)
{
   require_auth(get_self());
```

- [x] rename `modify_drop_binding` => `modify_ram_payer`
- [x] update method params of `check_drop_ownership` & `check_drop_bound`
```c++
void modify_ram_payer( const uint64_t drop_id, const name ram_payer );
void check_drop_ownership( const uint64_t drop_id, const name owner );
void check_drop_bound( const uint64_t drop_id, const bool bound );
```

- [x] rename `ram.hpp` methods to snake case (add "`_`")
  - `ramcost` to => `ram_cost`
  - `ramcostwithfee` to => `ram_cost_with_fee`
  - `ramproceedstminusfee` to => `ram_proceeds_minus_fee`

- [x] define  standard `ERROR_*` messages
  - `ERROR_INVALID_MEMO` => `Invalid transfer memo. (ex: "<amount>,<data>")`
  - `ERROR_DROP_NOT_FOUND` => `Drop not found.`
  - `ERROR_SYSTEM_DISABLED` => `Drops system is disabled.`
- [x] add comments for actions `@user` & `@admin`
- [x] modify `.find()` using `.get()`

```c++
auto & drop = drops.get(drop_id, ERROR_DROP_NOT_FOUND.c_str());
```

## New Tests
- [x] add `unbind` tests
  - Error: not found
  - Error: does not belong to account
  - Error: is not unbound
- [x] add `bind` tests
  - Error: not found
  - Error: does not belong to account
  - Error: is not bound
- [x] add `cancelunbind` tests
  - Error: No unbind request
- [x] add `on_transfer` error tests
  - Error - empty memo
  - Error - invalid number
  - Error - number underflow
  - Error - at least 32 characters