### PR TITLE
Added Wharfkit and refactored token refunds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+codegen
 node_modules
 *.wasm
 *.abi

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL := /bin/bash
 TEST_FILES := $(shell find src -name '*.ts')
 BIN := ./node_modules/.bin
 
-build:  | build/dir
+build: | build/dir
 	cdt-cpp -abigen -abigen_output=build/drops.abi -o build/drops.wasm src/drops.cpp -R src -I include -D DEBUG
 
 build/dir:
@@ -12,22 +12,22 @@ clean:
 	rm -rf build
 
 .PHONY: test
-test: build node_modules test/codegen
+test: build node_modules build/drops.ts init/codegen
 	bun test
 
-test/codegen: test/codegen/dir build/codegen/drops.ts build/codegen/eosio.ts build/codegen/eosio.token.ts 
+init/codegen: codegen/dir codegen/eosio.ts codegen/eosio.token.ts 
 
-test/codegen/dir:
-	mkdir -p build/codegen
+build/drops.ts: 
+	npx @wharfkit/cli generate --json ./build/drops.abi --file ./build/drops.ts drops
 
-build/codegen/drops.ts:
-	npx @wharfkit/cli generate --json ./build/drops.abi --file ./build/codegen/drops.ts drops
+codegen/dir:
+	mkdir -p codegen
 
-build/codegen/eosio.ts:
-	npx @wharfkit/cli generate --url https://jungle4.greymass.com --file ./build/codegen/eosio.ts eosio
+codegen/eosio.ts:
+	npx @wharfkit/cli generate --url https://jungle4.greymass.com --file ./codegen/eosio.ts eosio
 
-build/codegen/eosio.token.ts:
-	npx @wharfkit/cli generate --url https://jungle4.greymass.com --file ./build/codegen/eosio.token.ts eosio.token
+codegen/eosio.token.ts:
+	npx @wharfkit/cli generate --url https://jungle4.greymass.com --file ./codegen/eosio.token.ts eosio.token
 
 .PHONY: check
 check: cppcheck jscheck

--- a/Makefile
+++ b/Makefile
@@ -12,14 +12,28 @@ clean:
 	rm -rf build
 
 .PHONY: test
-test: node_modules build
+test: build node_modules test/codegen
 	bun test
+
+test/codegen: test/codegen/dir build/codegen/drops.ts build/codegen/eosio.ts build/codegen/eosio.token.ts 
+
+test/codegen/dir:
+	mkdir -p build/codegen
+
+build/codegen/drops.ts:
+	npx @wharfkit/cli generate --json ./build/drops.abi --file ./build/codegen/drops.ts drops
+
+build/codegen/eosio.ts:
+	npx @wharfkit/cli generate --url https://jungle4.greymass.com --file ./build/codegen/eosio.ts eosio
+
+build/codegen/eosio.token.ts:
+	npx @wharfkit/cli generate --url https://jungle4.greymass.com --file ./build/codegen/eosio.token.ts eosio.token
 
 .PHONY: check
 check: cppcheck jscheck
 
 .PHONY: cppcheck
-cppcheck:
+cppcheck: 
 	clang-format --dry-run --Werror src/*.cpp include/drops/*.hpp
 
 .PHONY: jscheck

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -175,10 +175,11 @@ private:
    int64_t  get_bytes_per_drop();
    uint64_t hash_data(const string data);
 
-   void transfer_tokens(const name to, const asset quantity, const string memo);
-   void transfer_ram(const name to, const int64_t bytes, const string memo);
-   void buy_ram_bytes(int64_t bytes);
-   void sell_ram_bytes(int64_t bytes);
+   void  transfer_tokens(const name to, const asset quantity, const string memo);
+   void  transfer_ram(const name to, const int64_t bytes, const string memo);
+   void  buy_ram_bytes(int64_t bytes);
+   void  sell_ram_bytes(int64_t bytes);
+   asset refund_remaining_tokens(const name account, const asset tokens_received, const asset tokens_spent);
 
    void check_is_enabled();
    void check_drop_owner(const drop_row drop, const name owner);

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -180,6 +180,7 @@ private:
    void  buy_ram_bytes(int64_t bytes);
    void  sell_ram_bytes(int64_t bytes);
    asset refund_remaining_tokens(const name account, const asset tokens_received, const asset tokens_spent);
+   asset buy_required_ram(const int64_t drop_quantity, const asset tokens_received);
 
    void check_is_enabled();
    void check_drop_owner(const drop_row drop, const name owner);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
         "test": "make test"
     },
     "dependencies": {
-        "@proton/vert": "^0.3.24"
+        "@proton/vert": "^0.3.24",
+        "@wharfkit/antelope": "^1.0.7",
+        "@wharfkit/contract": "^1.1.5"
     },
     "devDependencies": {
         "@types/bun": "^1.0.4",

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -35,7 +35,7 @@ drops::on_transfer(const name from, const name to, const asset quantity, const s
       check(parsed.size() == 2, ERROR_INVALID_MEMO);
 
       const int64_t amount = to_number(parsed[0]);
-      check(amount > 0, "amount must be a positive value.");
+      check(amount > 0, "The drops amount must be a positive value.");
       const string data = parsed[1];
       return do_generate(from, quantity, amount, data);
    }

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -20,7 +20,6 @@ drops::on_transfer(const name from, const name to, const asset quantity, const s
    if (from == get_self())
       return {}; // ignore transfers sent from this contract
 
-   check_is_enabled();
    check(get_first_receiver() == "eosio.token"_n, "Only the eosio.token contract may send tokens to this contract.");
    check(quantity.amount > 0, "The transaction amount must be a positive value.");
    check(quantity.symbol == EOS, "Only the system token is accepted for transfers.");

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -1,4 +1,5 @@
-import {Asset, Name, TimePointSec} from '@wharfkit/antelope'
+import {Asset, Name} from '@wharfkit/antelope'
+import {TimePointSec} from '@greymass/eosio'
 import {Blockchain, expectToThrow} from '@proton/vert'
 import {beforeEach, describe, expect, test} from 'bun:test'
 

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -35,10 +35,10 @@ function getBalance(account: string) {
     return Asset.from(contracts.token.tables.accounts(scope).getTableRow(primary_key).balance)
 }
 
-function getDrop(seed: bigint): DropsContract.Types.drop_row | undefined {
+function getDrop(seed: bigint): DropsContract.Types.drop_row {
     const scope = Name.from(core_contract).value.value
     const row = contracts.core.tables.drop(scope).getTableRow(seed)
-    if (!row) return undefined
+    if (!row) throw new Error('Drop not found')
     return DropsContract.Types.drop_row.from(row)
 }
 
@@ -190,7 +190,7 @@ describe(core_contract, () => {
         expect(transfer.memo).toBe('Reclaimed RAM value of 2 drops(s)')
         expect(after.units.value - before.units.value).toBe(1157)
         expect(getDrops(alice).length).toBe(8)
-        expect(getDrop(6530728038117924388n)).toBeUndefined()
+        expect(() => getDrop(6530728038117924388n)).toThrow('Drop not found')
     })
 
     test('destroy::error - not found', async () => {

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -53,6 +53,7 @@ function getUnbind(owner?: string): DropsContract.Types.unbind_row[] {
 }
 
 const ERROR_INVALID_MEMO = `eosio_assert_message: Invalid transfer memo. (ex: "<amount>,<data>")`
+const ERROR_SYSTEM_DISABLED = 'eosio_assert_message: Drops system is disabled.'
 
 describe(core_contract, () => {
     // Setup before each test
@@ -106,6 +107,14 @@ describe(core_contract, () => {
                 bound: false,
             })
         ).toBeTrue()
+    })
+
+    test('on_transfer::error - contract disabled', async () => {
+        await contracts.core.actions.enable([false]).send()
+        const action = contracts.token.actions
+            .transfer([alice, core_contract, '10.0000 EOS', ''])
+            .send(alice)
+        await expectToThrow(action, ERROR_SYSTEM_DISABLED)
     })
 
     test('on_transfer::error - empty memo', async () => {

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -12,11 +12,6 @@ const bob = 'bob'
 const alice = 'alice'
 blockchain.createAccounts(bob, alice)
 
-// one-time setup
-beforeEach(async () => {
-    blockchain.setTime(TimePointSec.from('2024-01-29T00:00:00.000'))
-})
-
 const core_contract = 'drops'
 const contracts = {
     core: blockchain.createContract(core_contract, `build/${core_contract}`, true),
@@ -60,6 +55,12 @@ function getUnbind(owner?: string): DropsContract.Types.unbind_row[] {
 const ERROR_INVALID_MEMO = `eosio_assert_message: Invalid transfer memo. (ex: "<amount>,<data>")`
 
 describe(core_contract, () => {
+    // Setup before each test
+    beforeEach(async () => {
+        blockchain.setTime(TimePointSec.from('2024-01-29T00:00:00.000'))
+        await contracts.core.actions.enable([true]).send()
+    })
+
     test('eosio::init', async () => {
         await contracts.system.actions.init([]).send()
     })

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -112,7 +112,7 @@ describe(core_contract, () => {
     test('on_transfer::error - contract disabled', async () => {
         await contracts.core.actions.enable([false]).send()
         const action = contracts.token.actions
-            .transfer([alice, core_contract, '10.0000 EOS', ''])
+            .transfer([alice, core_contract, '10.0000 EOS', '10,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'])
             .send(alice)
         await expectToThrow(action, ERROR_SYSTEM_DISABLED)
     })

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -1,6 +1,9 @@
-import {Asset, Name, TimePointSec} from '@greymass/eosio'
+import {Asset, Name, TimePointSec} from '@wharfkit/antelope'
 import {Blockchain, expectToThrow} from '@proton/vert'
 import {beforeEach, describe, expect, test} from 'bun:test'
+
+import * as DropsContract from '../build/codegen/drops.ts'
+import * as TokenContract from '../build/codegen/eosio.token.ts'
 
 // Vert EOS VM
 const blockchain = new Blockchain()
@@ -21,34 +24,9 @@ const contracts = {
     system: blockchain.createContract('eosio', 'include/eosio.system/eosio', true),
 }
 
-interface State {
-    genesis: string
-    bytes_per_drop: number
-    enabled: boolean
-}
-
-function getState() {
+function getState(): DropsContract.Types.state_row {
     const scope = Name.from(core_contract).value.value
-    return contracts.core.tables.state(scope).getTableRows()[0] as State
-}
-
-interface Drop {
-    seed: string
-    owner: string
-    created: string
-    bound: boolean
-}
-
-interface Transfer {
-    from: Name
-    to: Name
-    quantity: Asset
-    memo: string
-}
-
-interface Unbind {
-    owner: string
-    drops_ids: string[]
+    return contracts.core.tables.state(scope).getTableRows()[0]
 }
 
 function getBalance(account: string) {
@@ -57,21 +35,23 @@ function getBalance(account: string) {
     return Asset.from(contracts.token.tables.accounts(scope).getTableRow(primary_key).balance)
 }
 
-function getDrop(seed: bigint) {
+function getDrop(seed: bigint): DropsContract.Types.drop_row | undefined {
     const scope = Name.from(core_contract).value.value
-    return contracts.core.tables.drop(scope).getTableRow(seed) as Drop
+    const row = contracts.core.tables.drop(scope).getTableRow(seed)
+    if (!row) return undefined
+    return DropsContract.Types.drop_row.from(row)
 }
 
-function getDrops(owner?: string) {
+function getDrops(owner?: string): DropsContract.Types.drop_row[] {
     const scope = Name.from(core_contract).value.value
-    const rows = contracts.core.tables.drop(scope).getTableRows() as Drop[]
+    const rows = contracts.core.tables.drop(scope).getTableRows()
     if (!owner) return rows
     return rows.filter((row) => row.owner === owner)
 }
 
-function getUnbind(owner?: string) {
+function getUnbind(owner?: string): DropsContract.Types.unbind_row[] {
     const scope = Name.from(core_contract).value.value
-    const rows = contracts.core.tables.unbind(scope).getTableRows() as Unbind[]
+    const rows = contracts.core.tables.unbind(scope).getTableRows()
     if (!owner) return rows
     return rows.filter((row) => row.owner === owner)
 }
@@ -116,12 +96,14 @@ describe(core_contract, () => {
 
         expect(after.units.value - before.units.value).toBe(-5847)
         expect(getDrops(alice).length).toBe(10)
-        expect(getDrop(6530728038117924388n)).toEqual({
-            seed: '6530728038117924388',
-            owner: 'alice',
-            created: '2024-01-29T00:00:00.000',
-            bound: false,
-        })
+        expect(
+            getDrop(6530728038117924388n).equals({
+                seed: '6530728038117924388',
+                owner: 'alice',
+                created: '2024-01-29T00:00:00.000',
+                bound: false,
+            })
+        ).toBeTrue()
     })
 
     test('on_transfer::error - empty memo', async () => {
@@ -159,12 +141,14 @@ describe(core_contract, () => {
         await contracts.core.actions.mint([bob, 1, 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb']).send(bob)
 
         expect(getDrops(bob).length).toBe(1)
-        expect(getDrop(10272988527514872302n)).toEqual({
-            seed: '10272988527514872302',
-            owner: 'bob',
-            created: '2024-01-29T00:00:00.000',
-            bound: true,
-        })
+        expect(
+            getDrop(10272988527514872302n).equals({
+                seed: '10272988527514872302',
+                owner: 'bob',
+                created: '2024-01-29T00:00:00.000',
+                bound: true,
+            })
+        ).toBeTrue()
     })
 
     test('mint::error - already exists', async () => {
@@ -200,7 +184,7 @@ describe(core_contract, () => {
             .destroy([alice, ['6530728038117924388', '8833355934996727321'], 'memo'])
             .send(alice)
         const after = getBalance(alice)
-        const transfer: Transfer = blockchain.actionTraces[2].decodedData as any
+        const transfer = TokenContract.Types.transfer.from(blockchain.actionTraces[2].decodedData)
 
         expect(transfer.quantity.units.value.toNumber()).toBe(1157)
         expect(transfer.memo).toBe('Reclaimed RAM value of 2 drops(s)')

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -3,8 +3,8 @@ import {TimePointSec} from '@greymass/eosio'
 import {Blockchain, expectToThrow} from '@proton/vert'
 import {beforeEach, describe, expect, test} from 'bun:test'
 
-import * as DropsContract from '../build/codegen/drops.ts'
-import * as TokenContract from '../build/codegen/eosio.token.ts'
+import * as DropsContract from '../build/drops.ts'
+import * as TokenContract from '../codegen/eosio.token.ts'
 
 // Vert EOS VM
 const blockchain = new Blockchain()


### PR DESCRIPTION
## Whats new
- Removed an unneeded `check_is_enabled` from `on_transfer`
- Added `refund_remaining_tokens` function for use in `on_transfer` calls
- Renamed many generic parameter names to be more descriptive of what they are
- Refactored RAM buying logic into new `buy_required_ram` function

## Test Changes
- Added Wharf command line tools and integrated into Makefile. Each time the contract is built, the Wharf CLI will autogenerate new typescript types/interfaces based on the newly created ABI.
- Removed manually defined interfaces in tests for contract types, now using autogenerated types
- Added test to on_transfer for disabled contract
- Added beforeEach test hook to re-enable contract
