### PR TITLE
add sold RAM on claim

### DIFF
--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -24,7 +24,7 @@ static const string ERROR_ACCOUNT_NOT_EXISTS = "Account does not exist.";
 static const string ERROR_NO_DROPS           = "No drops were provided.";
 
 // memo messages
-static const string MEMO_RAM_TRANSFER = "Claiming RAM bytes.";
+static const string MEMO_RAM_TRANSFER      = "Claiming RAM bytes.";
 static const string MEMO_RAM_SOLD_TRANSFER = "Claiming sold RAM bytes.";
 
 // feature flags

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -25,9 +25,11 @@ static const string ERROR_NO_DROPS           = "No drops were provided.";
 
 // memo messages
 static const string MEMO_RAM_TRANSFER = "Claiming RAM bytes.";
+static const string MEMO_RAM_SOLD_TRANSFER = "Claiming sold RAM bytes.";
 
 // feature flags
 static const bool FLAG_FORCE_RECEIVER_TO_BE_SENDER = true;
+static const bool FLAG_RAM_TRANSFER_ON_CLAIM = false; // not available until system contract supports `ramtransfer`
 
 uint128_t combine_ids(const uint64_t& v1, const uint64_t& v2) { return (uint128_t{v1} << 64) | v2; }
 

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -290,7 +290,12 @@ bool drops::open_balance(const name owner, const name ram_payer)
    const int64_t ram_bytes = _balances.get(owner.value, ERROR_OPEN_BALANCE.c_str()).ram_bytes;
    if (ram_bytes > 0) {
       reduce_ram_bytes(owner, ram_bytes);
-      transfer_ram(owner, ram_bytes, MEMO_RAM_TRANSFER);
+      if (FLAG_RAM_TRANSFER_ON_CLAIM) {
+         transfer_ram(owner, ram_bytes, MEMO_RAM_TRANSFER);
+      } else {
+         const asset quantity = eosiosystem::ram_proceeds_minus_fee(ram_bytes, EOS);
+         transfer_tokens(owner, quantity, MEMO_RAM_SOLD_TRANSFER);
+      }
       return ram_bytes;
    }
    // else: account does not have any RAM bytes to claim

--- a/src/ram.cpp
+++ b/src/ram.cpp
@@ -105,8 +105,9 @@ asset ram_proceeds_minus_fee(uint32_t bytes, symbol core_symbol)
       check(false, "invalid conversion");
    }
 
-   const int64_t cost_minus_fee = out.amount * double(0.995);
-   return asset{cost_minus_fee, core_symbol};
+   const int64_t fee = (out.amount + 199) / 200; /// .5% fee (round up)
+   out.amount -= fee;
+   return out;
 }
 
 } // namespace eosiosystem


### PR DESCRIPTION
- add flag `FLAG_RAM_TRANSFER_ON_CLAIM=false`
  - true = transfer RAM (requires system contract upgrade to `ramtransfer`)
  - false = sell RAM, transfer EOS (only temporary until system contract supports `ramtransfer`)