### PR TITLE
add inline logging actions

### DIFF
--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -244,16 +244,16 @@ public:
    static void check_is_enabled(const name code) { check(is_enabled(code), ERROR_SYSTEM_DISABLED); }
 
    // action wrappers
-   using generate_action = eosio::action_wrapper<"generate"_n, &drops::generate>;
-   using transfer_action = eosio::action_wrapper<"transfer"_n, &drops::transfer>;
-   using destroy_action  = eosio::action_wrapper<"destroy"_n, &drops::destroy>;
-   using bind_action     = eosio::action_wrapper<"bind"_n, &drops::bind>;
-   using unbind_action   = eosio::action_wrapper<"unbind"_n, &drops::unbind>;
-   using enable_action   = eosio::action_wrapper<"enable"_n, &drops::enable>;
-   using open_action     = eosio::action_wrapper<"open"_n, &drops::open>;
-   using claim_action    = eosio::action_wrapper<"claim"_n, &drops::claim>;
-   using logbalances_action    = eosio::action_wrapper<"logbalances"_n, &drops::logbalances>;
-   using logstat_action    = eosio::action_wrapper<"logstat"_n, &drops::logstat>;
+   using generate_action    = eosio::action_wrapper<"generate"_n, &drops::generate>;
+   using transfer_action    = eosio::action_wrapper<"transfer"_n, &drops::transfer>;
+   using destroy_action     = eosio::action_wrapper<"destroy"_n, &drops::destroy>;
+   using bind_action        = eosio::action_wrapper<"bind"_n, &drops::bind>;
+   using unbind_action      = eosio::action_wrapper<"unbind"_n, &drops::unbind>;
+   using enable_action      = eosio::action_wrapper<"enable"_n, &drops::enable>;
+   using open_action        = eosio::action_wrapper<"open"_n, &drops::open>;
+   using claim_action       = eosio::action_wrapper<"claim"_n, &drops::claim>;
+   using logbalances_action = eosio::action_wrapper<"logbalances"_n, &drops::logbalances>;
+   using logstat_action     = eosio::action_wrapper<"logstat"_n, &drops::logstat>;
 
 // DEBUG (used to help testing)
 #ifdef DEBUG

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -244,14 +244,15 @@ public:
    static void check_is_enabled(const name code) { check(is_enabled(code), ERROR_SYSTEM_DISABLED); }
 
    // action wrappers
-   using generate_action    = eosio::action_wrapper<"generate"_n, &drops::generate>;
-   using transfer_action    = eosio::action_wrapper<"transfer"_n, &drops::transfer>;
-   using destroy_action     = eosio::action_wrapper<"destroy"_n, &drops::destroy>;
-   using bind_action        = eosio::action_wrapper<"bind"_n, &drops::bind>;
-   using unbind_action      = eosio::action_wrapper<"unbind"_n, &drops::unbind>;
-   using enable_action      = eosio::action_wrapper<"enable"_n, &drops::enable>;
-   using open_action        = eosio::action_wrapper<"open"_n, &drops::open>;
-   using claim_action       = eosio::action_wrapper<"claim"_n, &drops::claim>;
+   using generate_action = eosio::action_wrapper<"generate"_n, &drops::generate>;
+   using transfer_action = eosio::action_wrapper<"transfer"_n, &drops::transfer>;
+   using destroy_action  = eosio::action_wrapper<"destroy"_n, &drops::destroy>;
+   using bind_action     = eosio::action_wrapper<"bind"_n, &drops::bind>;
+   using unbind_action   = eosio::action_wrapper<"unbind"_n, &drops::unbind>;
+   using enable_action   = eosio::action_wrapper<"enable"_n, &drops::enable>;
+   using open_action     = eosio::action_wrapper<"open"_n, &drops::open>;
+   using claim_action    = eosio::action_wrapper<"claim"_n, &drops::claim>;
+
    using logbalances_action = eosio::action_wrapper<"logbalances"_n, &drops::logbalances>;
    using logstat_action     = eosio::action_wrapper<"logstat"_n, &drops::logstat>;
 

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -225,6 +225,12 @@ public:
    // @admin
    [[eosio::action]] void enable(bool enabled);
 
+   // @logging
+   void logbalances(const name owner, const int64_t drops, const int64_t ram_bytes);
+
+   // @logging
+   void logstat(const int64_t drops, const int64_t ram_bytes);
+
    // @static
    static bool is_enabled(const name code)
    {
@@ -246,6 +252,8 @@ public:
    using enable_action   = eosio::action_wrapper<"enable"_n, &drops::enable>;
    using open_action     = eosio::action_wrapper<"open"_n, &drops::open>;
    using claim_action    = eosio::action_wrapper<"claim"_n, &drops::claim>;
+   using logbalances_action    = eosio::action_wrapper<"logbalances"_n, &drops::logbalances>;
+   using logstat_action    = eosio::action_wrapper<"logstat"_n, &drops::logstat>;
 
 // DEBUG (used to help testing)
 #ifdef DEBUG
@@ -289,6 +297,10 @@ private:
    // create and destroy
    int64_t emplace_drops(const name owner, const bool bound, const uint32_t amount, const string data);
    bool    destroy_drop(const uint64_t drop_id, const name owner);
+
+   // logging
+   void log_balances(const name owner, const int64_t drops, const int64_t ram_bytes);
+   void log_stat(const int64_t drops, const int64_t ram_bytes);
 
 // DEBUG (used to help testing)
 #ifdef DEBUG

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -313,6 +313,7 @@ void drops::update_ram_bytes(const name owner, const int64_t bytes)
    _balances.modify(balance, auth_ram_payer(owner), [&](auto& row) {
       row.ram_bytes += bytes;
       check(row.ram_bytes >= 0, "Account does not have enough RAM bytes.");
+      log_balances(row.owner, row.drops, row.ram_bytes);
    });
 
    // add/reduce RAM bytes to contract (used for global limits)
@@ -320,6 +321,7 @@ void drops::update_ram_bytes(const name owner, const int64_t bytes)
    stat.ram_bytes += bytes;
    check(stat.ram_bytes >= 0, "Contract does not have enough RAM bytes."); // should never happen
    _stat.set(stat, get_self());
+   log_stat(stat.drops, stat.ram_bytes);
 }
 
 void drops::add_drops(const name owner, const int64_t amount) { return update_drops(name(), owner, amount); }
@@ -342,13 +344,19 @@ void drops::update_drops(const name from, const name to, const int64_t amount)
    // sender (if empty, minting new drops)
    if (from.value) {
       auto& balance_from = _balances.get(from.value, ERROR_OPEN_BALANCE.c_str());
-      _balances.modify(balance_from, auth_ram_payer(from), [&](auto& row) { row.drops -= amount; });
+      _balances.modify(balance_from, auth_ram_payer(from), [&](auto& row) {
+         row.drops -= amount;
+         log_balances(row.owner, row.drops, row.ram_bytes);
+      });
    }
 
    // receiver (if empty, burning drops)
    if (to.value) {
       auto& balance_to = _balances.get(to.value, ERROR_OPEN_BALANCE.c_str());
-      _balances.modify(balance_to, same_payer, [&](auto& row) { row.drops += amount; });
+      _balances.modify(balance_to, same_payer, [&](auto& row) {
+         row.drops += amount;
+         log_balances(row.owner, row.drops, row.ram_bytes);
+      });
    }
 
    // add drops to contract (used for global limits)
@@ -366,6 +374,7 @@ void drops::update_drops(const name from, const name to, const int64_t amount)
          check(stat.drops >= 0, "Contract does not have enough drops."); // should never happen
       }
       _stat.set(stat, get_self());
+      log_stat(stat.drops, stat.ram_bytes);
    }
 }
 

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -30,4 +30,24 @@ void drops::transfer_ram(const name to, const int64_t bytes, const string memo)
    ramtransfer.send(get_self(), to, bytes, memo);
 }
 
+void drops::log_balances(const name owner, const int64_t drops, const int64_t ram_bytes)
+{
+   drops::logbalances_action logbalances{get_self(), {get_self(), "active"_n}};
+   logbalances.send(owner, drops, ram_bytes);
+}
+
+void drops::logbalances(const name owner, const int64_t drops, const int64_t ram_bytes)
+{
+   require_auth(get_self());
+   require_recipient(owner);
+}
+
+void drops::log_stat(const int64_t drops, const int64_t ram_bytes)
+{
+   drops::logstat_action logstat{get_self(), {get_self(), "active"_n}};
+   logstat.send(drops, ram_bytes);
+}
+
+void drops::logstat(const int64_t drops, const int64_t ram_bytes) { require_auth(get_self()); }
+
 } // namespace dropssystem


### PR DESCRIPTION
- add two new logging actions triggered on:
  - `owner` balances changes (generate, destroy, transfer, unbind, bind)
  - `stat` changes (generate & destroy)

```c++
// @logging
void logbalances(const name owner, const int64_t drops, const int64_t ram_bytes);

// @logging
void logstat(const int64_t drops, const int64_t ram_bytes);
```