### PR TITLE
add `to_notify` param to actions

### DIFF
--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -165,14 +165,18 @@ public:
    on_transfer(const name from, const name to, const asset quantity, const string memo);
 
    // @user
-   [[eosio::action]] int64_t generate(const name owner, const bool bound, const uint32_t amount, const string data);
+   [[eosio::action]] int64_t generate(
+      const name owner, const bool bound, const uint32_t amount, const string data, const optional<name> to_notify);
 
    // @user
-   [[eosio::action]] void transfer(const name from, const name to, const vector<uint64_t> drops_ids, const string memo);
+   [[eosio::action]] void
+   transfer(const name from, const name to, const vector<uint64_t> drops_ids, const optional<string> memo);
 
    // @user
-   [[eosio::action]] destroy_return_value
-   destroy(const name owner, const vector<uint64_t> drops_ids, const string memo);
+   [[eosio::action]] destroy_return_value destroy(const name             owner,
+                                                  const vector<uint64_t> drops_ids,
+                                                  const optional<string> memo,
+                                                  const optional<name>   to_notify);
 
    // @user
    [[eosio::action]] int64_t bind(const name owner, const vector<uint64_t> drops_ids);
@@ -266,6 +270,7 @@ private:
    void buy_ram_bytes(int64_t bytes);
    void sell_ram_bytes(int64_t bytes);
    void buy_ram(const asset quantity);
+   void notify(const optional<name> to_notify);
 
    // ram balances helpers
    void update_ram_bytes(const name owner, const int64_t bytes);


### PR DESCRIPTION
add optional `to_notify` param to the following actions:
- [x] `destroy`
- [x] `generate`


```c++
// @user
[[eosio::action]]
int64_t generate( const name owner,
                  const bool bound,
                  const uint32_t amount,
                  const string data,
                  const optional<name> to_notify);
```
