### PR TITLE
fix inline actions logging & RAM claim

### DIFF
--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -232,12 +232,10 @@ public:
    [[eosio::action]] void enable(bool enabled);
 
    // @logging
-   [[eosio::action]]
-   void logbalances(const name owner, const int64_t drops, const int64_t ram_bytes);
+   [[eosio::action]] void logbalances(const name owner, const int64_t drops, const int64_t ram_bytes);
 
    // @logging
-   [[eosio::action]]
-   void logstat(const int64_t drops, const int64_t ram_bytes);
+   [[eosio::action]] void logstat(const int64_t drops, const int64_t ram_bytes);
 
    // @static
    static bool is_enabled(const name code)

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -29,8 +29,9 @@ static const string MEMO_RAM_SOLD_TRANSFER = "Claiming sold RAM bytes.";
 
 // feature flags
 static const bool FLAG_FORCE_RECEIVER_TO_BE_SENDER = true;
-static const bool FLAG_ENABLE_RAM_TRANSFER_ON_CLAIM =
-   false; // not available until system contract supports `ramtransfer`
+
+// not available until system contract supports `ramtransfer`
+static const bool FLAG_ENABLE_RAM_TRANSFER_ON_CLAIM = false;
 
 uint128_t combine_ids(const uint64_t& v1, const uint64_t& v2) { return (uint128_t{v1} << 64) | v2; }
 

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -232,9 +232,11 @@ public:
    [[eosio::action]] void enable(bool enabled);
 
    // @logging
+   [[eosio::action]]
    void logbalances(const name owner, const int64_t drops, const int64_t ram_bytes);
 
    // @logging
+   [[eosio::action]]
    void logstat(const int64_t drops, const int64_t ram_bytes);
 
    // @static

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -29,7 +29,7 @@ static const string MEMO_RAM_SOLD_TRANSFER = "Claiming sold RAM bytes.";
 
 // feature flags
 static const bool FLAG_FORCE_RECEIVER_TO_BE_SENDER = true;
-static const bool FLAG_RAM_TRANSFER_ON_CLAIM = false; // not available until system contract supports `ramtransfer`
+static const bool FLAG_ENABLE_RAM_TRANSFER_ON_CLAIM = false; // not available until system contract supports `ramtransfer`
 
 uint128_t combine_ids(const uint64_t& v1, const uint64_t& v2) { return (uint128_t{v1} << 64) | v2; }
 
@@ -219,14 +219,15 @@ public:
     * ### params
     *
     * - `{name} owner` - owner account to claim RAM bytes
+    * - `{bool} sell_ram` - whether to sell claimed RAM bytes (true = sellram, false = ramtransfer)
     *
     * ### example
     *
     * ```bash
-    * $ cleos push action core.drops claim '["alice"]' -p alice
+    * $ cleos push action core.drops claim '["alice", false]' -p alice
     * ```
     */
-   [[eosio::action]] int64_t claim(const name owner);
+   [[eosio::action]] int64_t claim(const name owner, const bool sell_ram);
 
    // @admin
    [[eosio::action]] void enable(bool enabled);

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -29,7 +29,8 @@ static const string MEMO_RAM_SOLD_TRANSFER = "Claiming sold RAM bytes.";
 
 // feature flags
 static const bool FLAG_FORCE_RECEIVER_TO_BE_SENDER = true;
-static const bool FLAG_ENABLE_RAM_TRANSFER_ON_CLAIM = false; // not available until system contract supports `ramtransfer`
+static const bool FLAG_ENABLE_RAM_TRANSFER_ON_CLAIM =
+   false; // not available until system contract supports `ramtransfer`
 
 uint128_t combine_ids(const uint64_t& v1, const uint64_t& v2) { return (uint128_t{v1} << 64) | v2; }
 

--- a/src/drops.contracts.md
+++ b/src/drops.contracts.md
@@ -107,3 +107,25 @@ summary: cleartable
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
 
 ---
+
+<h1 class="contract">logbalances</h1>
+
+---
+
+spec_version: "0.2.0"
+title: logbalances
+summary: logbalances
+icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
+---
+
+<h1 class="contract">logstat</h1>
+
+---
+
+spec_version: "0.2.0"
+title: logstat
+summary: logstat
+icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
+---

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -306,6 +306,7 @@ bool drops::open_balance(const name owner, const name ram_payer)
       if (FLAG_RAM_TRANSFER_ON_CLAIM) {
          transfer_ram(owner, ram_bytes, MEMO_RAM_TRANSFER);
       } else {
+         sell_ram_bytes(ram_bytes);
          const asset quantity = eosiosystem::ram_proceeds_minus_fee(ram_bytes, EOS);
          transfer_tokens(owner, quantity, MEMO_RAM_SOLD_TRANSFER);
       }

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -294,7 +294,7 @@ bool drops::open_balance(const name owner, const name ram_payer)
 }
 
 // @user
-[[eosio::action]] int64_t drops::claim(const name owner)
+[[eosio::action]] int64_t drops::claim(const name owner, const bool sell_ram)
 {
    require_auth(owner);
 
@@ -303,12 +303,13 @@ bool drops::open_balance(const name owner, const name ram_payer)
    const int64_t ram_bytes = _balances.get(owner.value, ERROR_OPEN_BALANCE.c_str()).ram_bytes;
    if (ram_bytes > 0) {
       reduce_ram_bytes(owner, ram_bytes);
-      if (FLAG_RAM_TRANSFER_ON_CLAIM) {
-         transfer_ram(owner, ram_bytes, MEMO_RAM_TRANSFER);
-      } else {
+      if (sell_ram) {
          sell_ram_bytes(ram_bytes);
          const asset quantity = eosiosystem::ram_proceeds_minus_fee(ram_bytes, EOS);
          transfer_tokens(owner, quantity, MEMO_RAM_SOLD_TRANSFER);
+      } else {
+         check(FLAG_ENABLE_RAM_TRANSFER_ON_CLAIM, "RAM transfer on claim is disabled.");
+         transfer_ram(owner, ram_bytes, MEMO_RAM_TRANSFER);
       }
       return ram_bytes;
    }

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -32,8 +32,8 @@ void drops::transfer_ram(const name to, const int64_t bytes, const string memo)
 
 void drops::log_balances(const name owner, const int64_t drops, const int64_t ram_bytes)
 {
-   drops::logbalances_action logbalances{get_self(), {get_self(), "active"_n}};
-   logbalances.send(owner, drops, ram_bytes);
+   drops::logbalances_action logbalances_act{get_self(), {get_self(), "active"_n}};
+   logbalances_act.send(owner, drops, ram_bytes);
 }
 
 void drops::logbalances(const name owner, const int64_t drops, const int64_t ram_bytes)
@@ -44,8 +44,8 @@ void drops::logbalances(const name owner, const int64_t drops, const int64_t ram
 
 void drops::log_stat(const int64_t drops, const int64_t ram_bytes)
 {
-   drops::logstat_action logstat{get_self(), {get_self(), "active"_n}};
-   logstat.send(drops, ram_bytes);
+   drops::logstat_action logstat_act{get_self(), {get_self(), "active"_n}};
+   logstat_act.send(drops, ram_bytes);
 }
 
 void drops::logstat(const int64_t drops, const int64_t ram_bytes) { require_auth(get_self()); }

--- a/src/ram.cpp
+++ b/src/ram.cpp
@@ -105,8 +105,7 @@ asset ram_proceeds_minus_fee(uint32_t bytes, symbol core_symbol)
       check(false, "invalid conversion");
    }
 
-   const int64_t fee = (out.amount + 199) / 200; /// .5% fee (round up)
-   out.amount -= fee;
+   out -= get_fee(out);
    return out;
 }
 


### PR DESCRIPTION
- [x] fixes inline logging issue
- [x] add `sell_ram_bytes` to claim
- [x] use `get_fee` method to calculate sell ram fee
- [x] add `sell_ram` boolean param to `claim`

```c++
// - `{bool} sell_ram` - whether to sell claimed RAM bytes (true = sellram, false = ramtransfer)
[[eosio::action]]
int64_t claim(const name owner, const bool sell_ram);
```

- [x] rename `FLAG_ENABLE_RAM_TRANSFER_ON_CLAIM` flag

```c++
// not available until system contract supports `ramtransfer`
static const bool FLAG_ENABLE_RAM_TRANSFER_ON_CLAIM = false;
```