### PR TITLE
Update logging and remove stat

### DIFF
--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -125,29 +125,6 @@ public:
       uint64_t primary_key() const { return owner.value; }
    };
 
-   /**
-    * ## TABLE `stat`
-    *
-    * ### params
-    *
-    * - `{int64_t} drops` - total supply of drops
-    * - `{int64_t} ram_bytes` - total available RAM bytes held by the contract
-    *
-    * ### example
-    *
-    * ```json
-    * {
-    *   "drops": 88888,
-    *   "ram_bytes": 2048
-    * }
-    * ```
-    */
-   struct [[eosio::table("stat")]] stat_row
-   {
-      int64_t drops;
-      int64_t ram_bytes;
-   };
-
    typedef eosio::multi_index<
       "drop"_n,
       drop_row,
@@ -155,7 +132,6 @@ public:
                                                           drop_table;
    typedef eosio::singleton<"state"_n, state_row>         state_table;
    typedef eosio::multi_index<"balances"_n, balances_row> balances_table;
-   typedef eosio::singleton<"stat"_n, stat_row>           stat_table;
 
    // @return
    struct destroy_return_value
@@ -221,24 +197,23 @@ public:
     * ### params
     *
     * - `{name} owner` - owner account to claim RAM bytes
-    * - `{bool} sell_ram` - whether to sell claimed RAM bytes (true = sellram, false = ramtransfer)
     *
     * ### example
     *
     * ```bash
-    * $ cleos push action core.drops claim '["alice", false]' -p alice
+    * $ cleos push action core.drops claim '["alice"]' -p alice
     * ```
     */
-   [[eosio::action]] int64_t claim(const name owner, const bool sell_ram);
+   [[eosio::action]] int64_t claim(const name owner);
 
    // @admin
    [[eosio::action]] void enable(bool enabled);
 
    // @logging
-   [[eosio::action]] void logbalances(const name owner, const int64_t drops, const int64_t ram_bytes);
+   [[eosio::action]] void logrambytes(const name owner, const int64_t before_ram_bytes, const int64_t ram_bytes);
 
    // @logging
-   [[eosio::action]] void logstat(const int64_t drops, const int64_t ram_bytes);
+   [[eosio::action]] void logdrops(const name owner, const int64_t before_drops, const int64_t drops);
 
    // @static
    static bool is_enabled(const name code)
@@ -262,8 +237,8 @@ public:
    using open_action     = eosio::action_wrapper<"open"_n, &drops::open>;
    using claim_action    = eosio::action_wrapper<"claim"_n, &drops::claim>;
 
-   using logbalances_action = eosio::action_wrapper<"logbalances"_n, &drops::logbalances>;
-   using logstat_action     = eosio::action_wrapper<"logstat"_n, &drops::logstat>;
+   using logrambytes_action = eosio::action_wrapper<"logrambytes"_n, &drops::logrambytes>;
+   using logdrops_action    = eosio::action_wrapper<"logdrops"_n, &drops::logdrops>;
 
 // DEBUG (used to help testing)
 #ifdef DEBUG
@@ -290,6 +265,7 @@ private:
    void update_ram_bytes(const name owner, const int64_t bytes);
    void add_ram_bytes(const name owner, const int64_t bytes);
    void reduce_ram_bytes(const name owner, const int64_t bytes);
+   void modify_ram_bytes(const name owner, const int64_t bytes, const name ram_payer);
 
    // drop balances helpers
    void update_drops(const name from, const name to, const int64_t amount);
@@ -310,8 +286,8 @@ private:
    bool    destroy_drop(const uint64_t drop_id, const name owner);
 
    // logging
-   void log_balances(const name owner, const int64_t drops, const int64_t ram_bytes);
-   void log_stat(const int64_t drops, const int64_t ram_bytes);
+   void log_drops(const name owner, const int64_t before_drops, const int64_t drops);
+   void log_ram_bytes(const name owner, const int64_t before_ram_bytes, const int64_t ram_bytes);
 
 // DEBUG (used to help testing)
 #ifdef DEBUG

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -24,7 +24,6 @@ drops::cleartable(const name table_name, const optional<name> scope, const optio
    // tables
    drops::state_table    _state(get_self(), value);
    drops::drop_table     _drop(get_self(), value);
-   drops::stat_table     _stat(get_self(), value);
    drops::balances_table _balances(get_self(), value);
 
    if (table_name == "drop"_n)
@@ -33,8 +32,6 @@ drops::cleartable(const name table_name, const optional<name> scope, const optio
       clear_table(_balances, rows_to_clear);
    else if (table_name == "state"_n)
       _state.remove();
-   else if (table_name == "stat"_n)
-      _stat.remove();
    else
       check(false, "cleartable: [table_name] unknown table to clear");
 }

--- a/src/drops.contracts.md
+++ b/src/drops.contracts.md
@@ -108,24 +108,24 @@ icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897
 
 ---
 
-<h1 class="contract">logbalances</h1>
+<h1 class="contract">logdrops</h1>
 
 ---
 
 spec_version: "0.2.0"
-title: logbalances
-summary: logbalances
+title: logdrops
+summary: logdrops
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
 
 ---
 
-<h1 class="contract">logstat</h1>
+<h1 class="contract">logrambytes</h1>
 
 ---
 
 spec_version: "0.2.0"
-title: logstat
-summary: logstat
+title: logrambytes
+summary: logrambytes
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
 
 ---

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -30,24 +30,31 @@ void drops::transfer_ram(const name to, const int64_t bytes, const string memo)
    ramtransfer.send(get_self(), to, bytes, memo);
 }
 
-void drops::log_balances(const name owner, const int64_t drops, const int64_t ram_bytes)
+void drops::log_ram_bytes(const name owner, const int64_t before_ram_bytes, const int64_t ram_bytes)
 {
-   drops::logbalances_action logbalances_act{get_self(), {get_self(), "active"_n}};
-   logbalances_act.send(owner, drops, ram_bytes);
+   drops::logrambytes_action logrambytes_act{get_self(), {get_self(), "active"_n}};
+   logrambytes_act.send(owner, before_ram_bytes, ram_bytes);
 }
 
-void drops::logbalances(const name owner, const int64_t drops, const int64_t ram_bytes)
+void drops::logrambytes(const name owner, const int64_t before_ram_bytes, const int64_t ram_bytes)
 {
    require_auth(get_self());
-   require_recipient(owner);
+   if (owner != get_self())
+      require_recipient(owner);
 }
 
-void drops::log_stat(const int64_t drops, const int64_t ram_bytes)
+void drops::log_drops(const name owner, const int64_t before_drops, const int64_t drops)
 {
-   drops::logstat_action logstat_act{get_self(), {get_self(), "active"_n}};
-   logstat_act.send(drops, ram_bytes);
+   drops::logdrops_action logdrops_act{get_self(), {get_self(), "active"_n}};
+   logdrops_act.send(owner, before_drops, drops);
 }
 
-void drops::logstat(const int64_t drops, const int64_t ram_bytes) { require_auth(get_self()); }
+void drops::logdrops(const name owner, const int64_t before_drops, const int64_t drops)
+{
+   require_auth(get_self());
+   if (owner != get_self()) {
+      require_recipient(owner);
+   }
+}
 
 } // namespace dropssystem


### PR DESCRIPTION
- [x] remove `stat` TABLE
- [x] prevent outgoing EOS transfers when `FLAG_ENABLE_RAM_TRANSFER_ON_CLAIM=true`
- [x] remove `sell_ram` param
- [x] prevent contract (self) from `drops::generate` be recipient of `drops::transfer`
- [x] add `modify_ram_bytes` helper method
- [x] replace `logbalances` & `logstat` with new logging actions `logrambytes` & `logdrops`
  - add `before_ram_bytes` & `before_drops` to logs
```c++
// @logging
[[eosio::action]]
void logrambytes(const name owner, const int64_t before_ram_bytes, const int64_t ram_bytes);

// @logging
[[eosio::action]]
void logdrops(const name owner, const int64_t before_drops, const int64_t drops);
```