### PR TITLE
add logdestroy

### DIFF
--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -229,14 +229,13 @@ public:
    logdrops(const name owner, const int64_t amount, const int64_t before_drops, const int64_t drops);
 
    // @logging
-   [[eosio::action]] void logdestroy(const name                    owner,
-                                     const vector<uint64_t>        drops_ids,
-                                     const vector<block_timestamp> created,
-                                     const int64_t                 destroyed,
-                                     const int64_t                 unbound_destroyed,
-                                     const int64_t                 bytes_reclaimed,
-                                     optional<string>              memo,
-                                     optional<name>                to_notify);
+   [[eosio::action]] void logdestroy(const name             owner,
+                                     const vector<drop_row> drops,
+                                     const int64_t          destroyed,
+                                     const int64_t          unbound_destroyed,
+                                     const int64_t          bytes_reclaimed,
+                                     optional<string>       memo,
+                                     optional<name>         to_notify);
 
    // @static
    static bool is_enabled(const name code)

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -228,6 +228,16 @@ public:
    [[eosio::action]] void
    logdrops(const name owner, const int64_t amount, const int64_t before_drops, const int64_t drops);
 
+   // @logging
+   [[eosio::action]] void logdestroy(const name                    owner,
+                                     const vector<uint64_t>        drops_ids,
+                                     const vector<block_timestamp> created,
+                                     const int64_t                 destroyed,
+                                     const int64_t                 unbound_destroyed,
+                                     const int64_t                 bytes_reclaimed,
+                                     optional<string>              memo,
+                                     optional<name>                to_notify);
+
    // @static
    static bool is_enabled(const name code)
    {
@@ -252,6 +262,7 @@ public:
 
    using logrambytes_action = eosio::action_wrapper<"logrambytes"_n, &drops::logrambytes>;
    using logdrops_action    = eosio::action_wrapper<"logdrops"_n, &drops::logdrops>;
+   using logdestroy_action  = eosio::action_wrapper<"logdestroy"_n, &drops::logdestroy>;
 
 // DEBUG (used to help testing)
 #ifdef DEBUG
@@ -301,7 +312,7 @@ private:
 
    // create and destroy
    generate_return_value emplace_drops(const name owner, const bool bound, const uint32_t amount, const string data);
-   bool                  destroy_drop(const uint64_t drop_id, const name owner);
+   drop_row              destroy_drop(const uint64_t drop_id, const name owner);
 
    // logging
    void log_drops(const name owner, const int64_t amount, const int64_t before_drops, const int64_t drops);

--- a/src/drops.contracts.md
+++ b/src/drops.contracts.md
@@ -135,3 +135,12 @@ title: logrambytes
 summary: logrambytes
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
 ---
+
+<h1 class="contract">logdestroy</h1>
+
+---
+spec_version: "0.2.0"
+title: logdestroy
+summary: logdestroy
+icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+---

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -261,15 +261,15 @@ void drops::notify(const optional<name> to_notify)
    reduce_drops(owner, amount);
 
    // The number of bound drops that were destroyed
-   int64_t                 unbound_destroyed = 0;
-   vector<block_timestamp> created;
+   int64_t          unbound_destroyed = 0;
+   vector<drop_row> drops;
    for (const uint64_t drop_id : drops_ids) {
       // Count the number of "bound=false" drops destroyed
       const drop_row drop = destroy_drop(drop_id, owner);
       if (drop.bound == false) {
          unbound_destroyed++;
       }
-      created.push_back(drop.created);
+      drops.push_back(drop);
    }
 
    // Calculate how much of their own RAM the account reclaimed
@@ -280,8 +280,7 @@ void drops::notify(const optional<name> to_notify)
 
    // logging
    drops::logdestroy_action logdestroy_act{get_self(), {get_self(), "active"_n}};
-   logdestroy_act.send(owner, drops_ids, created, drops_ids.size(), unbound_destroyed, bytes_reclaimed, memo,
-                       to_notify);
+   logdestroy_act.send(owner, drops, drops_ids.size(), unbound_destroyed, bytes_reclaimed, memo, to_notify);
 
    // action return value
    return {unbound_destroyed, bytes_reclaimed};

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -261,13 +261,15 @@ void drops::notify(const optional<name> to_notify)
    reduce_drops(owner, amount);
 
    // The number of bound drops that were destroyed
-   int64_t unbound_destroyed = 0;
+   int64_t                 unbound_destroyed = 0;
+   vector<block_timestamp> created;
    for (const uint64_t drop_id : drops_ids) {
       // Count the number of "bound=false" drops destroyed
-      const bool bound = destroy_drop(drop_id, owner);
-      if (bound == false) {
+      const drop_row drop = destroy_drop(drop_id, owner);
+      if (drop.bound == false) {
          unbound_destroyed++;
       }
+      created.push_back(drop.created);
    }
 
    // Calculate how much of their own RAM the account reclaimed
@@ -275,10 +277,17 @@ void drops::notify(const optional<name> to_notify)
    if (bytes_reclaimed > 0) {
       add_ram_bytes(owner, bytes_reclaimed);
    }
+
+   // logging
+   drops::logdestroy_action logdestroy_act{get_self(), {get_self(), "active"_n}};
+   logdestroy_act.send(owner, drops_ids, created, drops_ids.size(), unbound_destroyed, bytes_reclaimed, memo,
+                       to_notify);
+
+   // action return value
    return {unbound_destroyed, bytes_reclaimed};
 }
 
-bool drops::destroy_drop(const uint64_t drop_id, const name owner)
+drops::drop_row drops::destroy_drop(const uint64_t drop_id, const name owner)
 {
    drops::drop_table drops(get_self(), get_self().value);
 
@@ -290,7 +299,7 @@ bool drops::destroy_drop(const uint64_t drop_id, const name owner)
    drops.erase(drop);
 
    // return if the drop was bound or not
-   return bound;
+   return drop;
 }
 
 // @user

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -291,6 +291,18 @@ describe(core_contract, () => {
         expect(after.ram_bytes.value - before.ram_bytes.value).toBe(277 * 2)
         expect(after.drops.toNumber() - before.drops.toNumber()).toBe(-2)
         expect(() => getDrop(13991429617541607035n)).toThrow('Drop not found')
+
+        // logging
+        const logdestroy = DropsContract.Types.logdestroy.from(
+            blockchain.actionTraces[5].decodedData
+        )
+        expect(logdestroy.bytes_reclaimed.toNumber()).toEqual(554)
+        expect(logdestroy.unbound_destroyed.toNumber()).toEqual(2)
+        expect(logdestroy.destroyed.toNumber()).toEqual(2)
+        expect(logdestroy.created.map((v) => v.toString())).toEqual([
+            '2024-01-29T00:00:00.000',
+            '2024-01-29T00:00:00.000',
+        ])
     })
 
     test('destroy::error - not found', async () => {

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -299,7 +299,7 @@ describe(core_contract, () => {
         expect(logdestroy.bytes_reclaimed.toNumber()).toEqual(554)
         expect(logdestroy.unbound_destroyed.toNumber()).toEqual(2)
         expect(logdestroy.destroyed.toNumber()).toEqual(2)
-        expect(logdestroy.created.map((v) => v.toString())).toEqual([
+        expect(logdestroy.drops.map((v) => v.created.toString())).toEqual([
             '2024-01-29T00:00:00.000',
             '2024-01-29T00:00:00.000',
         ])

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -60,14 +60,13 @@ void drops::logdrops(const name owner, const int64_t amount, const int64_t befor
    }
 }
 
-[[eosio::action]] void drops::logdestroy(const name                    owner,
-                                         const vector<uint64_t>        drops_ids,
-                                         const vector<block_timestamp> created,
-                                         const int64_t                 destroyed,
-                                         const int64_t                 unbound_destroyed,
-                                         const int64_t                 bytes_reclaimed,
-                                         optional<string>              memo,
-                                         optional<name>                to_notify)
+[[eosio::action]] void drops::logdestroy(const name             owner,
+                                         const vector<drop_row> drops,
+                                         const int64_t          destroyed,
+                                         const int64_t          unbound_destroyed,
+                                         const int64_t          bytes_reclaimed,
+                                         optional<string>       memo,
+                                         optional<name>         to_notify)
 {
    require_auth(get_self());
    if (owner != get_self()) {

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -60,4 +60,22 @@ void drops::logdrops(const name owner, const int64_t amount, const int64_t befor
    }
 }
 
+[[eosio::action]] void drops::logdestroy(const name                    owner,
+                                         const vector<uint64_t>        drops_ids,
+                                         const vector<block_timestamp> created,
+                                         const int64_t                 destroyed,
+                                         const int64_t                 unbound_destroyed,
+                                         const int64_t                 bytes_reclaimed,
+                                         optional<string>              memo,
+                                         optional<name>                to_notify)
+{
+   require_auth(get_self());
+   if (owner != get_self()) {
+      require_recipient(owner);
+   }
+   if (to_notify) {
+      require_recipient(*to_notify);
+   }
+}
+
 } // namespace dropssystem

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -43,7 +43,7 @@ void drops::logrambytes(const name owner, const int64_t bytes, const int64_t bef
 {
    require_auth(get_self());
    if (owner != get_self())
-      require_recipient(owner);
+      notify(owner);
 }
 
 void drops::log_drops(const name owner, const int64_t amount, const int64_t before_drops, const int64_t drops)
@@ -56,7 +56,7 @@ void drops::logdrops(const name owner, const int64_t amount, const int64_t befor
 {
    require_auth(get_self());
    if (owner != get_self()) {
-      require_recipient(owner);
+      notify(owner);
    }
 }
 
@@ -70,10 +70,10 @@ void drops::logdrops(const name owner, const int64_t amount, const int64_t befor
 {
    require_auth(get_self());
    if (owner != get_self()) {
-      require_recipient(owner);
+      notify(owner);
    }
    if (to_notify) {
-      require_recipient(*to_notify);
+      notify(to_notify);
    }
 }
 


### PR DESCRIPTION
- [x] add `logdestroy`
- [x] include Vert tests for inline action logs

```c++
[[eosio::action]] void drops::logdestroy(const name                    owner,
                                         const vector<drop_row>        drops,
                                         const int64_t                 destroyed,
                                         const int64_t                 unbound_destroyed,
                                         const int64_t                 bytes_reclaimed,
                                         optional<string>              memo,
                                         optional<name>                to_notify)
```