### PR TITLE
Add logging tests

### DIFF
--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -237,6 +237,15 @@ public:
                                      optional<string>       memo,
                                      optional<name>         to_notify);
 
+   // @logging
+   [[eosio::action]] void loggenerate(const name             owner,
+                                      const vector<drop_row> drops,
+                                      const int64_t          generated,
+                                      const int64_t          bytes_used,
+                                      const int64_t          bytes_balance,
+                                      const string           data,
+                                      optional<name>         to_notify);
+
    // @static
    static bool is_enabled(const name code)
    {
@@ -262,6 +271,7 @@ public:
    using logrambytes_action = eosio::action_wrapper<"logrambytes"_n, &drops::logrambytes>;
    using logdrops_action    = eosio::action_wrapper<"logdrops"_n, &drops::logdrops>;
    using logdestroy_action  = eosio::action_wrapper<"logdestroy"_n, &drops::logdestroy>;
+   using loggenerate_action = eosio::action_wrapper<"loggenerate"_n, &drops::loggenerate>;
 
 // DEBUG (used to help testing)
 #ifdef DEBUG
@@ -310,8 +320,9 @@ private:
    uint64_t set_sequence(const int64_t amount);
 
    // create and destroy
-   generate_return_value emplace_drops(const name owner, const bool bound, const uint32_t amount, const string data);
-   drop_row              destroy_drop(const uint64_t drop_id, const name owner);
+   generate_return_value emplace_drops(
+      const name owner, const bool bound, const uint32_t amount, const string data, const optional<name> to_notify);
+   drop_row destroy_drop(const uint64_t drop_id, const name owner);
 
    // logging
    void log_drops(const name owner, const int64_t amount, const int64_t before_drops, const int64_t drops);

--- a/src/drops.contracts.md
+++ b/src/drops.contracts.md
@@ -144,3 +144,13 @@ title: logdestroy
 summary: logdestroy
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
 ---
+
+
+<h1 class="contract">loggenerate</h1>
+
+---
+spec_version: "0.2.0"
+title: loggenerate
+summary: loggenerate
+icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+---

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -378,8 +378,9 @@ int64_t drops::reduce_ram_bytes(const name owner, const int64_t bytes) { return 
 
 int64_t drops::update_ram_bytes(const name owner, const int64_t bytes)
 {
-   modify_ram_bytes(get_self(), bytes, get_self());
-   return modify_ram_bytes(owner, bytes, auth_ram_payer(owner));
+   const int64_t bytes_balance = modify_ram_bytes(owner, bytes, auth_ram_payer(owner));
+   modify_ram_bytes(get_self(), bytes, get_self()); // deduct RAM bytes from contract
+   return bytes_balance;
 }
 
 int64_t drops::modify_ram_bytes(const name owner, const int64_t bytes, const name ram_payer)

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -289,6 +289,14 @@ describe(core_contract, () => {
         await expectToThrow(action, 'eosio_assert: Cannot generate drops for contract.')
     })
 
+    test('generate::error - not have enough RAM bytes.', async () => {
+        const action = contracts.core.actions
+            .generate([alice, false, 1000, '1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'])
+            .send(alice)
+
+        await expectToThrow(action, 'eosio_assert_message: alice does not have enough RAM bytes.')
+    })
+
     test('generate 1K', async () => {
         const before = getBalance(bob)
         const data = 'cccccccccccccccccccccccccccccccc'

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -42,8 +42,7 @@ void drops::log_ram_bytes(const name    owner,
 void drops::logrambytes(const name owner, const int64_t bytes, const int64_t before_ram_bytes, const int64_t ram_bytes)
 {
    require_auth(get_self());
-   if (owner != get_self())
-      notify(owner);
+   notify(owner);
 }
 
 void drops::log_drops(const name owner, const int64_t amount, const int64_t before_drops, const int64_t drops)
@@ -55,9 +54,7 @@ void drops::log_drops(const name owner, const int64_t amount, const int64_t befo
 void drops::logdrops(const name owner, const int64_t amount, const int64_t before_drops, const int64_t drops)
 {
    require_auth(get_self());
-   if (owner != get_self()) {
-      notify(owner);
-   }
+   notify(owner);
 }
 
 [[eosio::action]] void drops::logdestroy(const name             owner,
@@ -69,12 +66,19 @@ void drops::logdrops(const name owner, const int64_t amount, const int64_t befor
                                          optional<name>         to_notify)
 {
    require_auth(get_self());
-   if (owner != get_self()) {
-      notify(owner);
-   }
-   if (to_notify) {
-      notify(to_notify);
-   }
+   notify(owner);
+}
+
+[[eosio::action]] void drops::loggenerate(const name             owner,
+                                          const vector<drop_row> drops,
+                                          const int64_t          generated,
+                                          const int64_t          bytes_used,
+                                          const int64_t          bytes_balance,
+                                          const string           data,
+                                          optional<name>         to_notify)
+{
+   require_auth(get_self());
+   notify(owner);
 }
 
 } // namespace dropssystem


### PR DESCRIPTION
- [x] add `loggenerate` inline action logging
- [x] handle `owner=get_self()` on `notify()` (shouldn't notify contract itself)
- [x] add more tests for inline logging actions
- [x] refactor: move `add_drops()` from `generate` to `emplace_drops()`
- [x] skip test: "generate::error - already exists" (is this even possible to test? 🤔 )
- [x] fix `reduce_ram` to mention user account instead of contact account
  - add test case for "not have enough RAM bytes."

```c++
   // @logging
   [[eosio::action]] void loggenerate(const name             owner,
                                      const vector<drop_row> drops,
                                      const int64_t          generated,
                                      const int64_t          bytes_used,
                                      const int64_t          bytes_balance,
                                      const string           data,
                                      optional<name>         to_notify);
```