### PR TITLE
Only include drops in log if `to_notify` is specified

### DIFF
--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -124,7 +124,11 @@ drops::generate_return_value drops::emplace_drops(
 
    // logging
    drops::loggenerate_action loggenerate_act{get_self(), {get_self(), "active"_n}};
-   loggenerate_act.send(owner, drops, drops.size(), bytes_used, bytes_balance, data, to_notify);
+   if (to_notify) {
+      loggenerate_act.send(owner, drops, drops.size(), bytes_used, bytes_balance, data, to_notify);
+   } else {
+      loggenerate_act.send(owner, vector<drop_row>(), drops.size(), bytes_used, bytes_balance, data, to_notify);
+   }
 
    // action return value
    return {bytes_used, bytes_balance};
@@ -292,7 +296,11 @@ void drops::notify(const optional<name> to_notify)
 
    // logging
    drops::logdestroy_action logdestroy_act{get_self(), {get_self(), "active"_n}};
-   logdestroy_act.send(owner, drops, drops.size(), unbound_destroyed, bytes_reclaimed, memo, to_notify);
+   if (to_notify) {
+      logdestroy_act.send(owner, drops, drops.size(), unbound_destroyed, bytes_reclaimed, memo, to_notify);
+   } else {
+      logdestroy_act.send(owner, vector<drop_row>(), drops.size(), unbound_destroyed, bytes_reclaimed, memo, to_notify);
+   }
 
    // action return value
    return {unbound_destroyed, bytes_reclaimed};

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -124,11 +124,8 @@ drops::generate_return_value drops::emplace_drops(
 
    // logging
    drops::loggenerate_action loggenerate_act{get_self(), {get_self(), "active"_n}};
-   if (to_notify) {
-      loggenerate_act.send(owner, drops, drops.size(), bytes_used, bytes_balance, data, to_notify);
-   } else {
-      loggenerate_act.send(owner, vector<drop_row>(), drops.size(), bytes_used, bytes_balance, data, to_notify);
-   }
+   loggenerate_act.send(owner, to_notify ? drops : vector<drop_row>(), drops.size(), bytes_used, bytes_balance, data,
+                        to_notify);
 
    // action return value
    return {bytes_used, bytes_balance};
@@ -296,11 +293,8 @@ void drops::notify(const optional<name> to_notify)
 
    // logging
    drops::logdestroy_action logdestroy_act{get_self(), {get_self(), "active"_n}};
-   if (to_notify) {
-      logdestroy_act.send(owner, drops, drops.size(), unbound_destroyed, bytes_reclaimed, memo, to_notify);
-   } else {
-      logdestroy_act.send(owner, vector<drop_row>(), drops.size(), unbound_destroyed, bytes_reclaimed, memo, to_notify);
-   }
+   logdestroy_act.send(owner, to_notify ? drops : vector<drop_row>(), drops.size(), unbound_destroyed, bytes_reclaimed,
+                       memo, to_notify);
 
    // action return value
    return {unbound_destroyed, bytes_reclaimed};

--- a/src/drops.spec.ts
+++ b/src/drops.spec.ts
@@ -188,7 +188,7 @@ describe(core_contract, () => {
 
         const data = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
         const before = getBalance(bob)
-        await contracts.core.actions.generate([bob, false, 1, data]).send(bob)
+        await contracts.core.actions.generate([bob, false, 1, data, bob]).send(bob)
         const after = getBalance(bob)
 
         // should consume RAM bytes
@@ -221,7 +221,7 @@ describe(core_contract, () => {
     test('generate - bound=true', async () => {
         const data = 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
         const before = getBalance(bob)
-        await contracts.core.actions.generate([bob, true, 1, data]).send(bob)
+        await contracts.core.actions.generate([bob, true, 1, data, bob]).send(bob)
         const after = getBalance(bob)
 
         // should not consume any RAM bytes
@@ -321,7 +321,7 @@ describe(core_contract, () => {
         await contracts.core.actions.generate([alice, false, 10, data]).send(alice)
         const before = getBalance(alice)
         await contracts.core.actions
-            .destroy([alice, ['13991429617541607035', '16719869299757338970'], 'memo'])
+            .destroy([alice, ['13991429617541607035', '16719869299757338970'], 'memo', alice])
             .send(alice)
         const after = getBalance(alice)
 


### PR DESCRIPTION
## Changes

- Only include the `drops` data if the `to_notify` field is specified for `generate` or `destroy`.