### PR TITLE
add read-only actions

### DIFF
--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -217,6 +217,9 @@ public:
     */
    [[eosio::action]] int64_t claim(const name owner);
 
+   [[eosio::action, eosio::read_only]] asset   ramcost(const int64_t bytes);
+   [[eosio::action, eosio::read_only]] int64_t bytescost(const asset quantity);
+
    // @admin
    [[eosio::action]] void enable(bool enabled);
 

--- a/src/drops.contracts.md
+++ b/src/drops.contracts.md
@@ -154,3 +154,21 @@ title: loggenerate
 summary: loggenerate
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
 ---
+
+<h1 class="contract">ramcost</h1>
+
+---
+spec_version: "0.2.0"
+title: ramcost
+summary: ramcost
+icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+---
+
+<h1 class="contract">bytescost</h1>
+
+---
+spec_version: "0.2.0"
+title: bytescost
+summary: bytescost
+icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+---

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -363,7 +363,7 @@ bool drops::open_balance(const name owner, const name ram_payer)
          // else, sell RAM bytes and transfer EOS to owner (0.5% fee to system contract)
       } else {
          sell_ram_bytes(ram_bytes);
-         const asset quantity = eosiosystem::ram_cost_with_fee(ram_bytes, EOS);
+         const asset quantity = eosiosystem::ram_proceeds_minus_fee(ram_bytes, EOS);
          transfer_tokens(owner, quantity, MEMO_RAM_SOLD_TRANSFER);
       }
       return ram_bytes;

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -2,6 +2,7 @@
 
 #include "helpers.cpp"
 #include "ram.cpp"
+#include "read_only.cpp"
 #include "utils.cpp"
 
 // DEBUG (used to help testing)
@@ -362,7 +363,7 @@ bool drops::open_balance(const name owner, const name ram_payer)
          // else, sell RAM bytes and transfer EOS to owner (0.5% fee to system contract)
       } else {
          sell_ram_bytes(ram_bytes);
-         const asset quantity = eosiosystem::ram_proceeds_minus_fee(ram_bytes, EOS);
+         const asset quantity = eosiosystem::ram_cost_with_fee(ram_bytes, EOS);
          transfer_tokens(owner, quantity, MEMO_RAM_SOLD_TRANSFER);
       }
       return ram_bytes;

--- a/src/ram.cpp
+++ b/src/ram.cpp
@@ -76,37 +76,9 @@ asset ram_cost(uint32_t bytes, symbol core_symbol)
 
 asset ram_cost_with_fee(uint32_t bytes, symbol core_symbol)
 {
-   const asset   cost          = ram_cost(bytes, core_symbol);
-   const int64_t cost_plus_fee = cost.amount / double(0.995);
-   return asset{cost_plus_fee, core_symbol};
-}
-
-// asset direct_convert(const asset& from, const symbol& to)
-asset ram_proceeds_minus_fee(uint32_t bytes, symbol core_symbol)
-{
-   asset from = asset{bytes, system_contract::ram_symbol};
-
-   symbol    to             = core_symbol;
-   name      system_account = "eosio"_n;
-   rammarket _rammarket(system_account, system_account.value);
-   auto      itr = _rammarket.find(system_contract::ramcore_symbol.raw());
-
-   const auto& sell_symbol  = from.symbol;
-   const auto& base_symbol  = itr->base.balance.symbol;
-   const auto& quote_symbol = itr->quote.balance.symbol;
-   check(sell_symbol != to, "cannot convert to the same symbol");
-
-   asset out(0, to);
-   if (sell_symbol == base_symbol && to == quote_symbol) {
-      out.amount = get_bancor_output(itr->base.balance.amount, itr->quote.balance.amount, from.amount);
-   } else if (sell_symbol == quote_symbol && to == base_symbol) {
-      out.amount = get_bancor_output(itr->quote.balance.amount, itr->base.balance.amount, from.amount);
-   } else {
-      check(false, "invalid conversion");
-   }
-
-   out -= get_fee(out);
-   return out;
+   const asset cost = ram_cost(bytes, core_symbol);
+   const asset fee  = get_fee(cost);
+   return cost - fee;
 }
 
 } // namespace eosiosystem

--- a/src/ram.cpp
+++ b/src/ram.cpp
@@ -78,6 +78,24 @@ asset ram_cost_with_fee(uint32_t bytes, symbol core_symbol)
 {
    const asset cost = ram_cost(bytes, core_symbol);
    const asset fee  = get_fee(cost);
+   return cost + fee;
+}
+
+asset ram_proceeds(uint32_t bytes, symbol core_symbol)
+{
+   name          system_account = "eosio"_n;
+   rammarket     _rammarket(system_account, system_account.value);
+   auto          itr         = _rammarket.find(system_contract::ramcore_symbol.raw());
+   const int64_t ram_reserve = itr->base.balance.amount;
+   const int64_t eos_reserve = itr->quote.balance.amount;
+   const int64_t cost        = get_bancor_output(ram_reserve, eos_reserve, bytes);
+   return asset{cost, core_symbol};
+}
+
+asset ram_proceeds_minus_fee(uint32_t bytes, symbol core_symbol)
+{
+   const asset cost = ram_proceeds(bytes, core_symbol);
+   const asset fee  = get_fee(cost);
    return cost - fee;
 }
 

--- a/src/read_only.cpp
+++ b/src/read_only.cpp
@@ -1,0 +1,9 @@
+[[eosio::action, eosio::read_only]] asset dropssystem::drops::ramcost(const int64_t bytes)
+{
+   return eosiosystem::ram_cost_with_fee(bytes, EOS);
+}
+
+[[eosio::action, eosio::read_only]] int64_t dropssystem::drops::bytescost(const asset quantity)
+{
+   return eosiosystem::bytes_cost_with_fee(quantity);
+}


### PR DESCRIPTION
## Add `read-only` actions

- [x] ramcost
- [x] bytescost
- [x] replace duplicate RAM method `ram_proceeds_minus_fee` with `ram_cost_with_fee`
- [x] use `get_fee()` method in `ram_cost_with_fee`

```c++
[[eosio::action, eosio::read_only]]
asset dropssystem::drops::ramcost(const int64_t bytes)
{
   return eosiosystem::ram_cost_with_fee(bytes, EOS);
}

[[eosio::action, eosio::read_only]]
int64_t dropssystem::drops::bytescost(const asset quantity)
{
   return eosiosystem::bytes_cost_with_fee(quantity);
}
```