### PR TITLE
RAM Transfers, memos, and renamed variables

### DIFF
--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -31,7 +31,7 @@ static const string MEMO_RAM_SOLD_TRANSFER = "Claiming sold RAM bytes.";
 static const bool FLAG_FORCE_RECEIVER_TO_BE_SENDER = true;
 
 // not available until system contract supports `ramtransfer`
-static const bool FLAG_ENABLE_RAM_TRANSFER_ON_CLAIM = false;
+static const bool FLAG_ENABLE_RAM_TRANSFER_ON_CLAIM = true;
 
 uint128_t combine_ids(const uint64_t& v1, const uint64_t& v2) { return (uint128_t{v1} << 64) | v2; }
 

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -161,19 +161,19 @@ public:
 
    // @user
    [[eosio::action]] void
-   transfer(const name from, const name to, const vector<uint64_t> drops_ids, const optional<string> memo);
+   transfer(const name from, const name to, const vector<uint64_t> droplet_ids, const optional<string> memo);
 
    // @user
    [[eosio::action]] destroy_return_value destroy(const name             owner,
-                                                  const vector<uint64_t> drops_ids,
+                                                  const vector<uint64_t> droplet_ids,
                                                   const optional<string> memo,
                                                   const optional<name>   to_notify);
 
    // @user
-   [[eosio::action]] int64_t bind(const name owner, const vector<uint64_t> drops_ids);
+   [[eosio::action]] int64_t bind(const name owner, const vector<uint64_t> droplet_ids);
 
    // @user
-   [[eosio::action]] int64_t unbind(const name owner, const vector<uint64_t> drops_ids);
+   [[eosio::action]] int64_t unbind(const name owner, const vector<uint64_t> droplet_ids);
 
    /**
     * ## ACTION `open`

--- a/include/drops/drops.hpp
+++ b/include/drops/drops.hpp
@@ -156,8 +156,12 @@ public:
    on_transfer(const name from, const name to, const asset quantity, const string memo);
 
    // @user
-   [[eosio::action]] generate_return_value generate(
-      const name owner, const bool bound, const uint32_t amount, const string data, const optional<name> to_notify);
+   [[eosio::action]] generate_return_value generate(const name             owner,
+                                                    const bool             bound,
+                                                    const uint32_t         amount,
+                                                    const string           data,
+                                                    const optional<name>   to_notify,
+                                                    const optional<string> memo);
 
    // @user
    [[eosio::action]] void
@@ -237,8 +241,8 @@ public:
                                      const int64_t          destroyed,
                                      const int64_t          unbound_destroyed,
                                      const int64_t          bytes_reclaimed,
-                                     optional<string>       memo,
-                                     optional<name>         to_notify);
+                                     const optional<string> memo,
+                                     const optional<name>   to_notify);
 
    // @logging
    [[eosio::action]] void loggenerate(const name             owner,
@@ -247,7 +251,8 @@ public:
                                       const int64_t          bytes_used,
                                       const int64_t          bytes_balance,
                                       const string           data,
-                                      optional<name>         to_notify);
+                                      const optional<name>   to_notify,
+                                      const optional<string> memo);
 
    // @static
    static bool is_enabled(const name code)
@@ -323,9 +328,13 @@ private:
    uint64_t set_sequence(const int64_t amount);
 
    // create and destroy
-   generate_return_value emplace_drops(
-      const name owner, const bool bound, const uint32_t amount, const string data, const optional<name> to_notify);
-   drop_row destroy_drop(const uint64_t drop_id, const name owner);
+   generate_return_value emplace_drops(const name             owner,
+                                       const bool             bound,
+                                       const uint32_t         amount,
+                                       const string           data,
+                                       const optional<name>   to_notify,
+                                       const optional<string> memo);
+   drop_row              destroy_drop(const uint64_t drop_id, const name owner);
 
    // logging
    void log_drops(const name owner, const int64_t amount, const int64_t before_drops, const int64_t drops);

--- a/src/drops.contracts.md
+++ b/src/drops.contracts.md
@@ -1,13 +1,15 @@
 <h1 class="contract">transfer</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: transfer
 summary: 'Transfer Drop(s)'
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
-{{from}} agrees to transfer {{drops_ids}} drops(s) to {{to}}.
+{{from}} agrees to transfer {{droplet_ids}} drops(s) to {{to}}.
 
 {{#if memo}}There is a memo attached to the transfer stating:
 {{memo}}
@@ -18,13 +20,15 @@ There is a notification to be sent to {{to}}.
 <h1 class="contract">destroy</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: destroy
 summary: 'Destroy Drop(s)'
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
-{{owner}} agrees to destroy {{drops_ids}} drops(s).
+{{owner}} agrees to destroy {{droplet_ids}} drops(s).
 
 {{#if memo}}There is a memo attached to the transfer stating:
 {{memo}}
@@ -36,32 +40,38 @@ icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897
 <h1 class="contract">bind</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: bind
 summary: 'Bind Drop(s)'
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
-{{owner}} agrees to bind {{drops_ids}} drops(s).
+{{owner}} agrees to bind {{droplet_ids}} drops(s).
 
 <h1 class="contract">unbind</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: unbind
 summary: 'Unbind Drop(s)'
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
-{{owner}} agrees to unbind {{drops_ids}} drops(s).
+{{owner}} agrees to unbind {{droplet_ids}} drops(s).
 
 <h1 class="contract">generate</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: generate
 summary: 'Generate Drop(s)'
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
 {{owner}} agrees to generate {{amount}} bound={{bound}} drops(s) using {{data}} data.
@@ -72,10 +82,12 @@ icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897
 <h1 class="contract">open</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: open
 summary: 'Open account balance'
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
 Opens RAM balance for {{owner}}.
@@ -83,10 +95,12 @@ Opens RAM balance for {{owner}}.
 <h1 class="contract">claim</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: claim
 summary: 'Claim remaining RAM balance'
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
 Claim any unclaimed RAM balance from the contract back to the {{owner}}'s account.
@@ -94,81 +108,98 @@ Claim any unclaimed RAM balance from the contract back to the {{owner}}'s accoun
 <h1 class="contract">enable</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: enable
 summary: 'Enable Drops contrat'
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
 <h1 class="contract">test</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: test
 summary: test
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
 <h1 class="contract">cleartable</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: cleartable
 summary: cleartable
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
 <h1 class="contract">logdrops</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: logdrops
 summary: logdrops
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
 <h1 class="contract">logrambytes</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: logrambytes
 summary: logrambytes
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
 <h1 class="contract">logdestroy</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: logdestroy
 summary: logdestroy
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
----
 
+---
 
 <h1 class="contract">loggenerate</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: loggenerate
 summary: loggenerate
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
 <h1 class="contract">ramcost</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: ramcost
 summary: ramcost
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---
 
 <h1 class="contract">bytescost</h1>
 
 ---
+
 spec_version: "0.2.0"
 title: bytescost
 summary: bytescost
 icon: https://avatars.githubusercontent.com/u/158113782#d3bf290fddeddbb7d32aa897e9f7e9e13a2ae44956142e23eb47b77096a2ea8d
+
 ---

--- a/src/drops.cpp
+++ b/src/drops.cpp
@@ -57,18 +57,26 @@ drops::on_transfer(const name from, const name to, const asset quantity, const s
 }
 
 // @user
-[[eosio::action]] drops::generate_return_value drops::generate(
-   const name owner, const bool bound, const uint32_t amount, const string data, const optional<name> to_notify)
+[[eosio::action]] drops::generate_return_value drops::generate(const name             owner,
+                                                               const bool             bound,
+                                                               const uint32_t         amount,
+                                                               const string           data,
+                                                               const optional<name>   to_notify,
+                                                               const optional<string> memo)
 {
    require_auth(owner);
    check_is_enabled(get_self());
    check(owner != get_self(), "Cannot generate drops for contract.");
    open_balance(owner, owner);
-   return emplace_drops(owner, bound, amount, data, to_notify);
+   return emplace_drops(owner, bound, amount, data, to_notify, memo);
 }
 
-drops::generate_return_value drops::emplace_drops(
-   const name owner, const bool bound, const uint32_t amount, const string data, const optional<name> to_notify)
+drops::generate_return_value drops::emplace_drops(const name             owner,
+                                                  const bool             bound,
+                                                  const uint32_t         amount,
+                                                  const string           data,
+                                                  const optional<name>   to_notify,
+                                                  const optional<string> memo)
 {
    drop_table _drops(get_self(), get_self().value);
 
@@ -126,7 +134,7 @@ drops::generate_return_value drops::emplace_drops(
    // logging
    drops::loggenerate_action loggenerate_act{get_self(), {get_self(), "active"_n}};
    loggenerate_act.send(owner, to_notify ? drops : vector<drop_row>(), drops.size(), bytes_used, bytes_balance, data,
-                        to_notify);
+                        to_notify, memo);
 
    // action return value
    return {bytes_used, bytes_balance};

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -62,8 +62,8 @@ void drops::logdrops(const name owner, const int64_t amount, const int64_t befor
                                          const int64_t          destroyed,
                                          const int64_t          unbound_destroyed,
                                          const int64_t          bytes_reclaimed,
-                                         optional<string>       memo,
-                                         optional<name>         to_notify)
+                                         const optional<string> memo,
+                                         const optional<name>   to_notify)
 {
    require_auth(get_self());
    notify(owner);
@@ -76,7 +76,8 @@ void drops::logdrops(const name owner, const int64_t amount, const int64_t befor
                                           const int64_t          bytes_used,
                                           const int64_t          bytes_balance,
                                           const string           data,
-                                          optional<name>         to_notify)
+                                          const optional<name>   to_notify,
+                                          const optional<string> memo)
 {
    require_auth(get_self());
    notify(owner);


### PR DESCRIPTION
- Enabled RAM transfers
- Renamed all instances of `drops_ids` to `droplet_ids` 
  - Resolves: https://github.com/droplets-system/drops/issues/44
- Added a `memo` field to `generate` and `loggenerate` 
  - Resolves: https://github.com/droplets-system/drops/issues/42